### PR TITLE
Fix for missing client IP when proxying to Insight

### DIFF
--- a/lib/insight/insight.js
+++ b/lib/insight/insight.js
@@ -16,7 +16,7 @@ class Insight {
 	}
 	performPOSTRequest(path, data, req, res) {
 		path = this.URI + path;
-    req.headers['x-forwarded-for'] = req.ip;
+		req.headers['x-forwarded-for'] = req.ip;
 		req.pipe(request.post({ url: path, form: data }), { end: false }).pipe(res);
 	}
 


### PR DESCRIPTION
Added x-forwarded-for header when proxying requests from DAPI to insight to allow insight to see original client IP