### PR TITLE
do not ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .vscode
 node_modules
 *.db
-package-lock.json
 dapinet.orbitdb


### PR DESCRIPTION
This file is intended to be checked in to version control to ensure consistent dependency versions.

Otherwise we open ourselves to updated packages, as well as vulnerabilities related to this (e.g. someone maliciously changes an upstream dependency in order to break this).

See https://stackoverflow.com/questions/44206782/do-i-commit-the-package-lock-json-file-created-by-npm-5 for more info.