### PR TITLE
[EV-1059] Fix Incorrect Hashing Procedure in sendRawTransition

### DIFF
--- a/lib/rpcServer/commands/sendRawTransition.js
+++ b/lib/rpcServer/commands/sendRawTransition.js
@@ -5,7 +5,21 @@ const Validator = require('../../utils/Validator');
 const argsSchema = require('../schemas/sendRawTransition');
 
 const validator = new Validator(argsSchema);
-const hash = crypto.createHash('sha256');
+
+/**
+ * Returns the string hex digest of a double SHA-256 hash.
+ * @param {String|Buffer} data The incoming data to hash
+ * @param {Object} cryptoLib The Node.js standard crypto library or equivalent
+ * @return {String}
+ */
+const doubleSha256 = (data, cryptoLib = crypto) => {
+  // The implementation of hash in Node.js is stateful and requires separate objects
+  const hasher1 = cryptoLib.createHash('sha256');
+  const firstHash = hasher1.update(data).digest('hex');
+  const hasher2 = cryptoLib.createHash('sha256');
+  const secondHashHexDigest = hasher2.update(firstHash).digest('hex');
+  return secondHashHexDigest;
+};
 
 const createStateTransition =
   ({
@@ -18,14 +32,15 @@ const createStateTransition =
       throw new Error('Updating state requires a transition data packet');
     }
 
-    const packet = Schema.serialize.decode(Buffer.from(rawTransitionDataPacket, 'hex'));
+    const rawTransitionDataPacketHexBuffer = Buffer.from(rawTransitionDataPacket, 'hex');
+    const packet = Schema.serialize.decode(rawTransitionDataPacketHexBuffer);
 
     const packetValidationResult = SchemaClass.validate.stpacket(packet);
     if (!packetValidationResult.valid) {
       throw new Error(`Invalid packet: ${packetValidationResult.errMsg}`);
     }
 
-    const packetHash = hash.update(rawTransitionDataPacket).digest('hex');
+    const packetHash = doubleSha256(rawTransitionDataPacketHexBuffer);
     // TODO: The following function is bugged and should be reported to Andy
     // const packetHash = SchemaClass.hash.stpacket(packet);
     const headerTransaction = new TransactionClass(rawTransitionHeader);
@@ -70,4 +85,5 @@ function sendRawTransitionFactory(coreAPI, dashDriveAPI) {
 }
 
 sendRawTransitionFactory.createStateTransition = createStateTransition;
+sendRawTransitionFactory.doubleSha256 = doubleSha256;
 module.exports = sendRawTransitionFactory;

--- a/test/rpcServer/commands/sendRawTransition.js
+++ b/test/rpcServer/commands/sendRawTransition.js
@@ -3,12 +3,25 @@ const chai = require('chai');
 const crypto = require('crypto');
 const Schema = require('@dashevo/dash-schema/dash-schema-lib');
 const { PrivateKey, Transaction } = require('@dashevo/dashcore-lib');
-const { createStateTransition } = require('../../../lib/rpcServer/commands/sendRawTransition');
+const { createStateTransition, doubleSha256 } = require('../../../lib/rpcServer/commands/sendRawTransition');
 
 const { expect } = chai;
 const hash = crypto.createHash('sha256');
 
 describe('sendRawTransition', () => {
+  describe('#doubleSha256', () => {
+    it('should return a doubleSha256 hex digest string given a String', () => {
+      const expected = 'c8549d3fc9d8688b9315d15eedae5c9e93bd08d7268d584a73d6c933a3261407';
+      const actual = doubleSha256('data');
+      expect(actual).to.equal(expected);
+    });
+    it('should return a doubleSha256 hex digest string given a Buffer', () => {
+      const dataBuffer = Buffer.from('data');
+      const expected = 'c8549d3fc9d8688b9315d15eedae5c9e93bd08d7268d584a73d6c933a3261407';
+      const actual = doubleSha256(dataBuffer);
+      expect(actual).to.equal(expected);
+    });
+  });
   describe('#createStateTransition', () => {
     it('should throw an error when no stateTransitionDataPacket given as an argument');
     it('should throw an error when the hash of the data packet does not match the hash in header');
@@ -32,7 +45,8 @@ describe('sendRawTransition', () => {
       };
 
       const rawTransitionDataPacket = Schema.serialize.encode(transitionDataPacket).toString('hex');
-      const packetHash = hash.update(rawTransitionDataPacket).digest('hex');
+      const rawTransitionDataPacketHexBuffer = Buffer.from(rawTransitionDataPacket, 'hex');
+      const packetHash = doubleSha256(rawTransitionDataPacketHexBuffer);
       const headerTransaction = new Transaction(rawTransitionHeader);
 
       headerTransaction.extraPayload.setHashSTPacket(packetHash);


### PR DESCRIPTION
**Issue being fixed or implemented**
The prior hashing algorithm used was a single SHA-256. This correctly implements a double SHA-256 hash instead.

**What was done**
-Added a `doubleSha256` utility function
-Used `doubleSha256` utility function instead of the previous straight hashing procedure
-Added additional export for `doubleSha256`
-Added additional unit tests to cover `doubleSha256`
-Fixed existing unit tests to cover the expected double hash

**What has been tested**
All of the new code has been tested. Tests were updated for the previous code.

**What needs to be tested**
The additional cases in `createRawTransitionPacket` still need to be unit tested in addition to a proper integration test for the endpoint itself.