### PR TITLE
[EV-1070] Fix deploy script and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,24 @@ FROM 103738324493.dkr.ecr.us-west-2.amazonaws.com/dashevo/v13-node-base:latest
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DAPI"
 
+ARG npm_token
+
 RUN apk update && apk --no-cache upgrade && apk add --no-cache git openssh-client python alpine-sdk libzmq zeromq-dev
 
 WORKDIR /dapi
 
 # copy package manifest separately from code to avoid installing packages every
 # time code is changed
-COPY package.json package-lock.json /dapi/
-RUN npm install
+COPY package.json /dapi/
+
+ENV NPM_TOKEN=$npm_token
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+
+RUN npm i
+
+# Token cleanup
+RUN unset NPM_TOKEN
+RUN rm .npmrc
 
 COPY . /dapi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ REPO_URL="103738324493.dkr.ecr.us-west-2.amazonaws.com"
 IMAGE_NAME="dashevo/dapi"
 
 # 1. build image:
-docker build -t "${IMAGE_NAME}:latest" -t "${IMAGE_NAME}:${VERSION}" .
+docker build -t "${IMAGE_NAME}:latest" -t "${IMAGE_NAME}:${VERSION}" --build-arg npm_token=$NPM_TOKEN  .
 
 # 2. After the build completes, tag your image so you can push the image to this repository:
 docker tag "${IMAGE_NAME}:latest" "${REPO_URL}/${IMAGE_NAME}:latest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,7 +267,7 @@
         },
         "lodash": {
           "version": "4.17.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.1.tgz",
           "integrity": "sha1-516vF6NHMMZJHZlW9NgfOgRPAb8="
         },
         "punycode": {
@@ -302,7 +302,7 @@
       "dependencies": {
         "lodash": {
           "version": "4.17.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.1.tgz",
           "integrity": "sha1-516vF6NHMMZJHZlW9NgfOgRPAb8="
         }
       }


### PR DESCRIPTION
### Issue being fixed or implemented
Can't build and deploy a docker image using Dockerfile and deploy script

### What was done
Added a build argument `npm_token` to the dockerfile, change deploy script to use NPM_TOKEN env variable

### What has been tested
Deployed new DAPI image with fixed script

### What needs to be tested
n/a

### Comment
Not sure if the npm token isn't leaked in any way. I think unsetting the env variable and removing .npmrc file should be enough, but may be I lack some knowledge.