### PR TITLE
update copyright in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 The Dash Evolution developers
+Copyright (c) 2017-2018 Dash Core Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fix copyright attribution (use correct company name) and add current year. Since work was done in both years, it should be correct listing both.