### PR TITLE
[EV-1193] autodeploy doesn't work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os: linux
 language: node_js
 branches:
   only:
-    - develop
     - master
 node_js:
   - '8'
@@ -27,4 +26,4 @@ deploy:
   script: /bin/bash deploy.sh
   on:
     repo: dashevo/dapi
-    branch: develop
+    branch: master


### PR DESCRIPTION
**Issue being fixed or implemented**
we don't build and don't push dapi container after every commit in master
**What was done**
previously we use develop branch but it doesn't exist anymore. we need to switch on master branch for auto deploy
**What has been tested**
n/a
**What needs to be tested**
new dapi container should be published after commit in master
**Code Coverage**
n/a