### PR TITLE
Fix hardcoded version in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ echo "Docker deploy started"
 eval $(~/.local/bin/aws ecr get-login --no-include-email)
 
 # 0.5. set the current version:
-VERSION="1.0.0"
+VERSION=$(node -p "require('./package.json').version")
 REPO_URL="103738324493.dkr.ecr.us-west-2.amazonaws.com"
 IMAGE_NAME="dashevo/dapi"
 


### PR DESCRIPTION
### Issue being fixed or implemented
- All docker images had the same hardcoded version in the tag

### What was done
- Changed deploy script to include a version from the `package.json` file as the image tag