### PR TITLE
remove getHashFromHeight & updates for getBlockHash

### DIFF
--- a/lib/externalApis/dashcore/rpc.js
+++ b/lib/externalApis/dashcore/rpc.js
@@ -83,16 +83,6 @@ const getBlockHeaders = (offset, limit) => new Promise((resolve, reject) => {
   });
 });
 
-const getHashFromHeight = height => new Promise((resolve, reject) => {
-  client.getblockhash(height, (err, r) => {
-    if (err) {
-      reject(new DashCoreRpcError(err.message));
-    } else {
-      resolve(r.result);
-    }
-  });
-});
-
 const getMasternodesList = () => new Promise((resolve, reject) => {
   client.masternodelist((err, r) => {
     if (err) {
@@ -252,7 +242,6 @@ module.exports = {
   getBlock,
   getBlockHeader,
   getBlockHeaders,
-  getHashFromHeight,
   getMasternodesList,
   getMempoolInfo,
   getMnListDiff,

--- a/lib/externalApis/insight/index.js
+++ b/lib/externalApis/insight/index.js
@@ -36,11 +36,6 @@ const getTransactionFirstInputAddress = async (txHash) => {
   return res.vin[0].addr;
 };
 
-const getHashFromHeight = async (height) => {
-  const res = await get(`/block-index/${height}`);
-  return res.blockHash;
-};
-
 const getUTXO = async (address, from, to, fromHeight, toHeight) => {
   const addresses = Array.isArray(address) ? address.join() : address;
   const res = await get(`/addrs/${addresses}/utxopage?from=${from}&to=${to}&fromHeight=${fromHeight}&to=${toHeight}`);
@@ -58,11 +53,6 @@ const getMasternodesList = async () => get('/masternodes/list');
 const getBestBlockHeight = async () => {
   const res = await get('/status');
   return res.info.blocks;
-};
-
-const getBlockHash = async (blockHeight) => {
-  const res = await get(`/block-index/${blockHeight}`);
-  return res.blockHash;
 };
 
 const getAddressTotalReceived = async (address) => {
@@ -149,7 +139,6 @@ const getBlockHeaders = async (offset, limit) => get(`/block-headers/${offset}/$
 
 module.exports = {
   getTransactionFirstInputAddress,
-  getHashFromHeight,
   request,
   get,
   post,
@@ -157,7 +146,6 @@ module.exports = {
   getBalance,
   getUser,
   getBestBlockHeight,
-  getBlockHash,
   getMasternodesList,
   getAddressTotalReceived,
   getBlocks,

--- a/test/unit/api/dashcore/rpc.js
+++ b/test/unit/api/dashcore/rpc.js
@@ -8,44 +8,10 @@ const coreAPIFixture = require('../../../mocks/coreAPIFixture');
 
 const { expect } = chai;
 chai.use(chaiAsPromised);
-let spy;
 let stub;
 
 describe('externalApis/dashcore/rpc', async () => {
   const rpc = require('../../../../lib/externalApis/dashcore/rpc');
-
-  describe('getHashFromHeight', () => {
-    describe('#factory', () => {
-      it('should return a promise', async () => {
-        const getHashFromHeight = rpc.getHashFromHeight();
-        expect(getHashFromHeight).to.be.a('promise');
-      });
-      it('should return error with invalid height', async () => {
-        const getHashFromHeight = rpc.getHashFromHeight('1');
-        await expect(getHashFromHeight).to.be.rejectedWith('JSON');
-        expect(spy.callCount).to.be.equal(1);
-      });
-      it('should return error with invalid height', async () => {
-        const getHashFromHeight = rpc.getHashFromHeight('str');
-        await expect(getHashFromHeight).to.be.rejectedWith('JSON');
-        expect(spy.callCount).to.be.equal(1);
-      });
-      it('Should return a hash', async () => {
-        expect(spy.callCount).to.be.equal(0);
-        await expect(rpc.getHashFromHeight(1)).to.be.rejectedWith('JSON');
-        expect(spy.callCount).to.be.equal(1);
-      });
-    });
-    before(() => {
-      spy = sinon.spy(rpc, 'getHashFromHeight');
-    });
-    beforeEach(() => {
-      spy.resetHistory();
-    });
-    after(() => {
-      spy.restore();
-    });
-  });
 
   describe('getTransaction', () => {
     const txHash = '50622f66236671501c0e80f388d6cf1e81158de8526f4acc9db00adf3c524077';
@@ -54,10 +20,6 @@ describe('externalApis/dashcore/rpc', async () => {
       it('should return a promise', () => {
         const getTransaction = rpc.getTransaction();
         expect(getTransaction).to.be.a('promise');
-      });
-      it('should return error with invalid transaction', async () => {
-        const getHashFromHeight = rpc.getTransaction(1);
-        await expect(getHashFromHeight).to.be.rejectedWith('JSON');
       });
     });
     describe('#stub', () => {

--- a/test/unit/api/insight/insight.js
+++ b/test/unit/api/insight/insight.js
@@ -571,53 +571,6 @@
 //     });
 //   });
 //
-//   describe('#getHashFromHeight', () => {
-//     beforeEach(() => {
-//       requestStub = sinon.stub(request, 'get');
-//       requestStub.rejects(new Error('Invalid address: Checksum mismatch. Code:1'));
-//       requestStub
-//         .withArgs(`${URI}/block-index/${testBlockHeight}`)
-//         .returns(new Promise(resolve => resolve(testHashFromHeight)));
-//     });
-//
-//     it('Should return getBalance', async () => {
-//       const hashFromHeight = await insight.getHashFromHeight(testBlockHeight);
-//       expect(hashFromHeight).to.be.equal(testHashFromHeight.blockHash);
-//     });
-//
-//     // https://dashpay.atlassian.net/browse/EV-950
-//     // we can set any value like:
-//     //42c56c8ec8e2cdf97a56bf6290c43811ff59181a184b70ebbe3cb66b2970ced2
-//     // and results for 42 will be set
-//     [testAddress.addrStr.substring(0, testAddress.addrStr.length - 1),
-//       testAddress.addrStr.substring(1, testAddress.addrStr.length), 123456789].forEach((ad) => {
-//       it('Should return error if Invalid address: Checksum mismatch',
-// () => expect(insight.getHashFromHeight(ad))
-//         .to.be.rejectedWith('Invalid address: Checksum mismatch. Code:1'));
-//     });
-//
-//     [23498217349279, false, 'fakjfndkjlanmfdas', '0x'].forEach((ad) => {
-//       it(
-//         'Should return error if JSON value is not an integer as expected. Code:-1',
-//         () => {
-//           requestStub.rejects(new Error('JSON value is not an integer as expected. Code:-1'));
-//           expect(insight.getHashFromHeight(ad))
-// .to.be.rejectedWith('JSON value is not an integer as expected. Code:-1');
-//         },
-//       );
-//     });
-//
-//     ['1396bc62950f8b3a3811f1134b64816273c72d19d9641d747cfd55bea9e120bd'].forEach((ad) => {
-//       it(
-//         'Should return error if Block height out of range. Code:-8',
-//         () => {
-//           requestStub.rejects(new Error('Block height out of range. Code:-8'));
-//           expect(insight.getHashFromHeight(ad))
-// .to.be.rejectedWith('Block height out of range. Code:-8');
-//         },
-//       );
-//     });
-//   });
 //
 //   describe('#getHistoricBlockchainDataSyncStatus', () => {
 //     beforeEach(() => {

--- a/test/unit/rpcServer/commands/generate.js
+++ b/test/unit/rpcServer/commands/generate.js
@@ -38,19 +38,19 @@ describe('generate', () => {
   });
 
   it('Should throw an error if arguments are not valid', async () => {
-    const getBlockHash = generateFactory(coreAPIFixture);
+    const generate = generateFactory(coreAPIFixture);
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash({ amount: -1 })).to.be.rejectedWith('should be >= 0');
+    await expect(generate({ amount: -1 })).to.be.rejectedWith('should be >= 0');
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash({ amount: 0.5 })).to.be.rejectedWith('should be integer');
+    await expect(generate({ amount: 0.5 })).to.be.rejectedWith('should be integer');
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash({})).to.be.rejectedWith('should have required property');
+    await expect(generate({})).to.be.rejectedWith('should have required property');
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash()).to.be.rejectedWith('should be object');
+    await expect(generate()).to.be.rejectedWith('should be object');
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash({ amount: 'string' })).to.be.rejectedWith('should be integer');
+    await expect(generate({ amount: 'string' })).to.be.rejectedWith('should be integer');
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash([-1])).to.be.rejected;
+    await expect(generate([-1])).to.be.rejected;
     expect(spy.callCount).to.be.equal(0);
   });
 });

--- a/test/unit/rpcServer/commands/getBlockHash.js
+++ b/test/unit/rpcServer/commands/getBlockHash.js
@@ -39,15 +39,15 @@ describe('getBlockHash', () => {
   it('Should throw an error if arguments are not valid', async () => {
     const getBlockHash = getBlockHashFactory(coreAPIFixture);
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash({ height: -1 })).to.be.rejectedWith('should be >= 0');
+    await expect(getBlockHash({ height: -1 })).to.be.rejectedWith('params.height should be >= 0');
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash({ height: 0.5 })).to.be.rejectedWith('should be integer');
+    await expect(getBlockHash({ height: 0.5 })).to.be.rejectedWith('params.height should be integer');
     expect(spy.callCount).to.be.equal(0);
     await expect(getBlockHash({})).to.be.rejectedWith('should have required property');
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash()).to.be.rejectedWith('should be object');
+    await expect(getBlockHash()).to.be.rejectedWith('params should be object');
     expect(spy.callCount).to.be.equal(0);
-    await expect(getBlockHash({ height: 'string' })).to.be.rejectedWith('should be integer');
+    await expect(getBlockHash({ height: 'string' })).to.be.rejectedWith('params.height should be integer');
     expect(spy.callCount).to.be.equal(0);
     await expect(getBlockHash([-1])).to.be.rejected;
     expect(spy.callCount).to.be.equal(0);


### PR DESCRIPTION
**Issue being fixed or implemented**
- remove getHashFromHeight from insight and core APIs ( it's never used in dapi-client and it has the same functionality as getBlockHash)
- remove getBlockHash from insight to not support unused code

**What was done**
only getBlockHash from core API remained.

**What has been tested**
test code updated, integration tests were run

**What needs to be tested**
no additional verification required ( unit and integration tests should pass)