### PR TITLE
Handle errors from GRPC method handlers

### DIFF
--- a/lib/grpcServer/createServer.js
+++ b/lib/grpcServer/createServer.js
@@ -11,6 +11,10 @@ const {
 
 const { loadPackageDefinition } = require('@dashevo/dapi-grpc');
 
+const wrapInErrorHandlerFactory = require('./error/wrapInErrorHandlerFactory');
+
+const wrapInErrorHandler = wrapInErrorHandlerFactory(console);
+
 const getTransactionsByFilterHandlerFactory = require('./handlers/getTransactionsByFilterHandlerFactory');
 
 function createServer() {
@@ -31,8 +35,10 @@ function createServer() {
     TransactionsFilterStream,
   } = loadPackageDefinition();
 
+  const getTransactionsByFilterHandler = getTransactionsByFilterHandlerFactory();
+
   server.addService(TransactionsFilterStream.service, {
-    getTransactionsByFilter: getTransactionsByFilterHandlerFactory(),
+    getTransactionsByFilter: wrapInErrorHandler(getTransactionsByFilterHandler),
   });
 
   return server;

--- a/lib/grpcServer/error/GrpcError.js
+++ b/lib/grpcServer/error/GrpcError.js
@@ -1,0 +1,30 @@
+class GrpcError extends Error {
+  /**
+   * @param {string} message
+   * @param {number} code
+   * @param {Object} [metadata]
+   */
+  constructor(code, message, metadata = undefined) {
+    super(message);
+
+    this.code = code;
+    this.metadata = metadata;
+
+    Error.captureStackTrace(this.constructor);
+  }
+
+  getCode() {
+    return this.code;
+  }
+
+  getMetadata() {
+    return this.metadata();
+  }
+}
+
+GrpcError.CODES = {
+  INTERNAL: 13,
+  INVALID_ARGUMENT: 3,
+};
+
+module.exports = GrpcError;

--- a/lib/grpcServer/error/GrpcError.js
+++ b/lib/grpcServer/error/GrpcError.js
@@ -14,6 +14,15 @@ class GrpcError extends Error {
   }
 
   /**
+   * Get message
+   *
+   * @return {string}
+   */
+  getMessage() {
+    return this.message;
+  }
+
+  /**
    * Get error code
    *
    * @return {number}

--- a/lib/grpcServer/error/GrpcError.js
+++ b/lib/grpcServer/error/GrpcError.js
@@ -13,12 +13,22 @@ class GrpcError extends Error {
     Error.captureStackTrace(this.constructor);
   }
 
+  /**
+   * Get error code
+   *
+   * @return {number}
+   */
   getCode() {
     return this.code;
   }
 
+  /**
+   * Get metadata
+   *
+   * @return {Object}
+   */
   getMetadata() {
-    return this.metadata();
+    return this.metadata;
   }
 }
 

--- a/lib/grpcServer/error/InternalError.js
+++ b/lib/grpcServer/error/InternalError.js
@@ -1,0 +1,23 @@
+const GrpcError = require('./GrpcError');
+
+class InternalError extends GrpcError {
+  /**
+   * @param {Error} error
+   */
+  constructor(error) {
+    super(GrpcError.CODES.INTERNAL, 'Internal error');
+
+    this.error = error;
+  }
+
+  /**
+   * Get error
+   *
+   * @return {Error}
+   */
+  getError() {
+    return this.error;
+  }
+}
+
+module.exports = InternalError;

--- a/lib/grpcServer/error/InvalidArgumentError.js
+++ b/lib/grpcServer/error/InvalidArgumentError.js
@@ -1,6 +1,6 @@
 const GrpcError = require('./GrpcError');
 
-class InternalError extends GrpcError {
+class InvalidArgumentError extends GrpcError {
   /**
    * @param {string} message
    * @param {Object} [metadata]
@@ -10,4 +10,4 @@ class InternalError extends GrpcError {
   }
 }
 
-module.exports = InternalError;
+module.exports = InvalidArgumentError;

--- a/lib/grpcServer/error/InvalidArgumentError.js
+++ b/lib/grpcServer/error/InvalidArgumentError.js
@@ -1,0 +1,13 @@
+const GrpcError = require('./GrpcError');
+
+class InternalError extends GrpcError {
+  /**
+   * @param {string} message
+   * @param {Object} [metadata]
+   */
+  constructor(message, metadata = undefined) {
+    super(GrpcError.CODES.INVALID_ARGUMENT, `Invalid argument: ${message}`, metadata);
+  }
+}
+
+module.exports = InternalError;

--- a/lib/grpcServer/error/wrapInErrorHandlerFactory.js
+++ b/lib/grpcServer/error/wrapInErrorHandlerFactory.js
@@ -1,0 +1,40 @@
+const GrpcError = require('./GrpcError');
+const InternalError = require('./InternalError');
+
+/**
+ * @param {Object} logger
+ * @return wrapInErrorHandler
+ */
+module.exports = function wrapInErrorHandlerFactory(logger) {
+  /**
+   * Wrap RPC method in error handler
+   *
+   * @typedef wrapInErrorHandler
+   * @param {Function} method RPC method
+   * @return {Function}
+   */
+  function wrapInErrorHandler(method) {
+    /**
+     * @param {Object} call
+     * @param {function(Error, *)} callback
+     */
+    function rpcMethodErrorHandler(call, callback) {
+      try {
+        method(call, callback);
+      } catch (e) {
+        if (e instanceof GrpcError) {
+          callback(e, null);
+        } else {
+          const internalError = new InternalError(e);
+
+          logger.error(e);
+
+          callback(internalError, null);
+        }
+      }
+    }
+    return rpcMethodErrorHandler;
+  }
+
+  return wrapInErrorHandler;
+};

--- a/test/unit/grpcServer/error/GrpcError.spec.js
+++ b/test/unit/grpcServer/error/GrpcError.spec.js
@@ -1,0 +1,45 @@
+const { expect, use } = require('chai');
+const dirtyChai = require('dirty-chai');
+
+const GrpcError = require('../../../../lib/grpcServer/error/GrpcError');
+
+use(dirtyChai);
+
+describe('GrpcError', () => {
+  let code;
+  let message;
+  let metadata;
+  let error;
+
+  beforeEach(() => {
+    code = 1;
+    message = 'Message';
+    metadata = {};
+
+    error = new GrpcError(code, message, metadata);
+  });
+
+  describe('#getMessage', () => {
+    it('should return message', () => {
+      const result = error.getMessage();
+
+      expect(result).to.equal(message);
+    });
+  });
+
+  describe('#getCode', () => {
+    it('should return code', () => {
+      const result = error.getCode();
+
+      expect(result).to.equal(code);
+    });
+  });
+
+  describe('#getMetadata', () => {
+    it('should return metadata', () => {
+      const result = error.getMetadata();
+
+      expect(result).to.equal(metadata);
+    });
+  });
+});

--- a/test/unit/grpcServer/error/InternalError.spec.js
+++ b/test/unit/grpcServer/error/InternalError.spec.js
@@ -1,0 +1,34 @@
+const { expect, use } = require('chai');
+const dirtyChai = require('dirty-chai');
+
+const GrpcError = require('../../../../lib/grpcServer/error/GrpcError');
+const InternalError = require('../../../../lib/grpcServer/error/InternalError');
+
+use(dirtyChai);
+
+describe('InternalError', () => {
+  let error;
+  let internalError;
+
+  beforeEach(() => {
+    error = new Error();
+
+    internalError = new InternalError(error);
+  });
+
+  describe('#getError', () => {
+    it('should return error', () => {
+      const result = internalError.getError();
+
+      expect(result).to.equal(error);
+    });
+  });
+
+  describe('#getCode', () => {
+    it('should return INTERNAL error code', () => {
+      const result = internalError.getCode();
+
+      expect(result).to.equal(GrpcError.CODES.INTERNAL);
+    });
+  });
+});

--- a/test/unit/grpcServer/error/InvalidArgumentError.spec.js
+++ b/test/unit/grpcServer/error/InvalidArgumentError.spec.js
@@ -1,0 +1,44 @@
+const { expect, use } = require('chai');
+const dirtyChai = require('dirty-chai');
+
+const GrpcError = require('../../../../lib/grpcServer/error/GrpcError');
+const InvalidArgumentError = require('../../../../lib/grpcServer/error/InvalidArgumentError');
+
+use(dirtyChai);
+
+describe('InvalidArgumentError', () => {
+  let message;
+  let metadata;
+  let error;
+
+  beforeEach(() => {
+    message = 'Message';
+    metadata = {};
+
+    error = new InvalidArgumentError(message, metadata);
+  });
+
+  describe('#getMessage', () => {
+    it('should return message', () => {
+      const result = error.getMessage();
+
+      expect(result).to.equal(`Invalid argument: ${message}`);
+    });
+  });
+
+  describe('#getCode', () => {
+    it('should return INVALID_ARGUMENT error code', () => {
+      const result = error.getCode();
+
+      expect(result).to.equal(GrpcError.CODES.INVALID_ARGUMENT);
+    });
+  });
+
+  describe('#getMetadata', () => {
+    it('should return metadata', () => {
+      const result = error.getMetadata();
+
+      expect(result).to.equal(metadata);
+    });
+  });
+});

--- a/test/unit/grpcServer/error/wrapInErrorHandlerFactory.spec.js
+++ b/test/unit/grpcServer/error/wrapInErrorHandlerFactory.spec.js
@@ -1,0 +1,100 @@
+const { expect, use } = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const dirtyChai = require('dirty-chai');
+const chaiAsPromised = require('chai-as-promised');
+
+const wrapInErrorHandlerFactory = require('../../../../lib/grpcServer/error/wrapInErrorHandlerFactory');
+const InternalError = require('../../../../lib/grpcServer/error/InternalError');
+const InvalidArgumentError = require('../../../../lib/grpcServer/error/InvalidArgumentError');
+
+use(sinonChai);
+use(chaiAsPromised);
+use(dirtyChai);
+
+describe('wrapInErrorHandlerFactory', () => {
+  beforeEach(function beforeEach() {
+    if (!this.sinon) {
+      this.sinon = sinon.createSandbox();
+    } else {
+      this.sinon.restore();
+    }
+  });
+
+  afterEach(function afterEach() {
+    this.sinon.restore();
+  });
+
+  let loggerMock;
+  let wrapInErrorHandler;
+  let rpcMethod;
+  let callback;
+  let call;
+
+  beforeEach(function beforeEach() {
+    loggerMock = {
+      error: this.sinon.stub(),
+    };
+
+    wrapInErrorHandler = wrapInErrorHandlerFactory(loggerMock);
+
+    rpcMethod = this.sinon.stub();
+    callback = this.sinon.stub();
+    call = {};
+  });
+
+  it('should return wrapped RPC method', () => {
+    const wrappedRpcMethod = wrapInErrorHandler(rpcMethod);
+
+    expect(wrappedRpcMethod).to.be.a('function');
+    expect(rpcMethod).to.not.be.called();
+  });
+
+  describe('wrapped RPC method', () => {
+    it('should call a method', () => {
+      const wrappedRpcMethod = wrapInErrorHandler(rpcMethod);
+
+      wrappedRpcMethod(call, callback);
+
+      expect(rpcMethod).to.be.calledOnceWith(call, callback);
+      expect(callback).to.not.be.called();
+      expect(loggerMock.error).to.not.be.called();
+    });
+
+    it('should call callback with GrpcError if it was thrown from the method', () => {
+      const wrappedRpcMethod = wrapInErrorHandler(rpcMethod);
+
+      const grpcError = new InvalidArgumentError('Something wrong');
+
+      rpcMethod.throws(grpcError);
+
+      wrappedRpcMethod(call, callback);
+
+      expect(rpcMethod).to.be.calledOnceWith(call, callback);
+      expect(callback).to.be.calledOnceWith(grpcError);
+      expect(loggerMock.error).to.not.be.called();
+    });
+
+    it('should log and call callback with InternalError if some error except GrpcError was thrown from the method', () => {
+      const wrappedRpcMethod = wrapInErrorHandler(rpcMethod);
+
+      const someError = new Error();
+
+      rpcMethod.throws(someError);
+
+      wrappedRpcMethod(call, callback);
+
+      expect(rpcMethod).to.be.calledOnceWith(call, callback);
+
+      expect(callback).to.be.calledOnce();
+      expect(callback.getCall(0).args).to.have.lengthOf(2);
+
+      const [grpcError] = callback.getCall(0).args;
+
+      expect(grpcError).to.be.instanceOf(InternalError);
+      expect(grpcError.getError()).to.equal(someError);
+
+      expect(loggerMock.error).to.be.calledOnceWith(someError);
+    });
+  });
+});


### PR DESCRIPTION
In order to handle errors from GRPC method handlers, I wrapped them into additional closure with error handling logic.