### PR TITLE
Start lastProcessedBlock with 0 for userIndex

### DIFF
--- a/lib/services/userIndex.js
+++ b/lib/services/userIndex.js
@@ -11,7 +11,7 @@ let logger;
 
 let usernameCache = [];
 const userCache = {};
-let lastProcessedBlock = 1;
+let lastProcessedBlock = 0;
 
 let isUpdating = false;
 


### PR DESCRIPTION
**Issue being fixed or implemented**
now in userIndex we start with lastProcessedBlock=1. When we launch clean master node and generate genesis block we trigger indexing with lastProcessedBlock += 1; => block out of range

**What was done**
initial lastProcessedBlock=0 and we should start indexing from the first block

**What has been tested**
integration tests works with the fix

*What needs to be tested*
no additional verification required ( unit and integration tests should pass)