### PR TITLE
Update `fetchDocuments` OAS default values

### DIFF
--- a/lib/rpcServer/commands/fetchDocuments.js
+++ b/lib/rpcServer/commands/fetchDocuments.js
@@ -98,15 +98,15 @@ const fetchDocumentsFactory = (driveAPI) => {
  *                          description: Mongo-like sort field
  *                        limit:
  *                          type: integer
- *                          default: ''
+ *                          default: 1
  *                          description: How many objects to fetch
  *                        startAt:
  *                          type: integer
- *                          default: ''
+ *                          default: 0
  *                          description: Number of objects to skip
  *                        startAfter:
  *                          type: integer
- *                          default: ''
+ *                          default: 0
  *                          description: Exlusive skip
  */
 /* eslint-enable max-len */

--- a/lib/rpcServer/commands/fetchDocuments.js
+++ b/lib/rpcServer/commands/fetchDocuments.js
@@ -98,7 +98,7 @@ const fetchDocumentsFactory = (driveAPI) => {
  *                          description: Mongo-like sort field
  *                        limit:
  *                          type: integer
- *                          default: 1
+ *                          default: 100
  *                          description: How many objects to fetch
  *                        startAt:
  *                          type: integer


### PR DESCRIPTION
 - Was setting integer default to empty string instead of number

Are these good default values to use? They are really only relevant if importing the spec into a site for hosting interactively.