### PR TITLE
fix: load .env at correct time for tx-filter-stream

### DIFF
--- a/scripts/tx-filter-stream.js
+++ b/scripts/tx-filter-stream.js
@@ -26,6 +26,9 @@ const {
   getTransactionsFilterStreamDefinition,
 } = require('@dashevo/dapi-grpc');
 
+// Load config from .env
+dotenv.config();
+
 const config = require('../lib/config');
 const { validateConfig } = require('../lib/config/validator');
 const log = require('../lib/log');
@@ -44,8 +47,6 @@ const subscribeToNewTransactions = require('../lib/transactionsFilter/subscribeT
 const getHistoricalTransactionsIteratorFactory = require('../lib/transactionsFilter/getHistoricalTransactionsIteratorFactory');
 
 async function main() {
-  dotenv.config();
-
   // Validate config
   const configValidationResult = validateConfig(config);
   if (!configValidationResult.isValid) {


### PR DESCRIPTION
Fixes the issue that prevents `npm run tx-filter-stream` from working properly if a `.env` file is used by moving `dotenv.config();` to match how it is done in [`api.js`](https://github.com/dashevo/dapi/blob/v0.10-dev/scripts/api.js#L20-L23).

If possible, it seems like this would be better done in [`lib/config/index.js`](https://github.com/dashevo/dapi/blob/v0.10-dev/lib/config/index.js#L47) and removed from the other locations.

Thanks to @nmarley for helping out.
Fixes #228 