### PR TITLE
test: update functional tests to work with dapi-client v0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,9 +144,9 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "0.14.0-dev.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.14.0-dev.4.tgz",
-      "integrity": "sha512-Cvq//l4qdhTaFy0/djHzL+I6sPuultL/pWqU4az871SnuME0/iYzAZPnGDLyJiIA8DDaQrwuPmiLDRVYdMTJdQ==",
+      "version": "0.14.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.14.0-dev.5.tgz",
+      "integrity": "sha512-jbYAcUwPV1TvHuQx4hhlqZz2OBaxohG7lzEHD09AWVe+A+lCUHd3gJeQImEk5Mt89UKITAK0J8Fa8+29mgDfKw==",
       "dev": true,
       "requires": {
         "@dashevo/dapi-grpc": "~0.14.0-dev.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,16 +87,6 @@
       "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
       "dev": true
     },
-    "@babel/polyfill": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.1.tgz",
-      "integrity": "sha512-TviueJ4PBW5p48ra8IMtLXVkDucrlOZAIZ+EXqS3Ot4eukHbWiqcn7DcqpA1k5PcKtmJ4Xl9xwdv6yQvvcA+3g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
@@ -154,22 +144,31 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.13.0.tgz",
-      "integrity": "sha512-ttbg08wkV6Z2gpxj/ksVuQAf2YOLAOiWMEVh+sc7v9zbWfEGd16HmpwDWVP8lzdMGG/P910+UeDi6bjYdnwZDQ==",
+      "version": "0.14.0-dev.4",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.14.0-dev.4.tgz",
+      "integrity": "sha512-Cvq//l4qdhTaFy0/djHzL+I6sPuultL/pWqU4az871SnuME0/iYzAZPnGDLyJiIA8DDaQrwuPmiLDRVYdMTJdQ==",
       "dev": true,
       "requires": {
-        "@babel/polyfill": "^7.8.3",
-        "@dashevo/dapi-grpc": "~0.13.0",
-        "@dashevo/dash-spv": "^1.1.6",
-        "@dashevo/dashcore-lib": "~0.18.0",
-        "@dashevo/dpp": "~0.13.0",
+        "@dashevo/dapi-grpc": "~0.14.0-dev.1",
+        "@dashevo/dashcore-lib": "^0.18.1",
         "axios": "^0.19.2",
         "cbor": "^5.0.1",
-        "lodash": "^4.17.15",
-        "lowdb": "^1.0.0"
+        "lodash.sample": "^4.2.1"
       },
       "dependencies": {
+        "@dashevo/dapi-grpc": {
+          "version": "0.14.0-dev.1",
+          "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.14.0-dev.1.tgz",
+          "integrity": "sha512-o5l5nH7ZuIMv9fSOScy6orPyAxTR//EsxMP3SGfrybCOf0fjS2FttlbHGdMbC5A21a/Og4ms1zQgf0QquaFfgw==",
+          "dev": true,
+          "requires": {
+            "@dashevo/grpc-common": "^0.3.0",
+            "google-protobuf": "^3.8.0",
+            "grpc": "^1.24.2",
+            "grpc-web": "^1.0.6",
+            "protobufjs": "^6.8.8"
+          }
+        },
         "cbor": {
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.2.tgz",
@@ -192,59 +191,6 @@
         "grpc": "^1.24.2",
         "grpc-web": "^1.0.6",
         "protobufjs": "^6.8.8"
-      }
-    },
-    "@dashevo/dark-gravity-wave": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dark-gravity-wave/-/dark-gravity-wave-1.1.1.tgz",
-      "integrity": "sha512-rt0PzGzqplqERWVIMLlBxm4mJqjFTYNUFRhIccbfaF/MDyd0/585krGOWIhe0Sis9XQNA/FJlxxRjtPXIcyyCg==",
-      "dev": true
-    },
-    "@dashevo/dash-spv": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-1.1.6.tgz",
-      "integrity": "sha512-pAZlwN4UJkht68zSq7MmqMZIHcvuah69UT7KM6RBeGrSEPaw1wxiz772tJ3Q/Px4FOHf3Uwc63ylOe7Vnbk1qA==",
-      "dev": true,
-      "requires": {
-        "@dashevo/dark-gravity-wave": "^1.1.1",
-        "@dashevo/dash-util": "^2.0.3",
-        "@dashevo/dashcore-lib": "^0.17.4",
-        "levelup": "^4.0.1",
-        "memdown": "^3.0.0"
-      },
-      "dependencies": {
-        "@dashevo/dashcore-lib": {
-          "version": "0.17.12",
-          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
-          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
-          "dev": true,
-          "requires": {
-            "@dashevo/x11-hash-js": "^1.0.2",
-            "bloom-filter": "^0.2.0",
-            "bn.js": "=4.11.8",
-            "bs58": "=4.0.1",
-            "elliptic": "=6.4.1",
-            "inherits": "=2.0.1",
-            "lodash": "^4.17.15",
-            "unorm": "^1.4.1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
-      }
-    },
-    "@dashevo/dash-util": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-util/-/dash-util-2.0.3.tgz",
-      "integrity": "sha512-fnc76NYVBhuTLhuUVidnV9sKSsMxmkxkhUOjiD/ny6Ipyo+qxwKeFAn8SvdVzlEpflNA613B+hsxmTBBGazl4A==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.6.4",
-        "buffer-reverse": "^1.0.1"
       }
     },
     "@dashevo/dashcore-lib": {
@@ -285,12 +231,12 @@
       }
     },
     "@dashevo/dp-services-ctl": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dp-services-ctl/-/dp-services-ctl-0.13.1.tgz",
-      "integrity": "sha512-kTpMwdXkKGQXxs6oDw9tvVCW9VWSyF23tBcLX5jfgx8633CK9TqexIhiQC3EnDJkGl0p5+SFlDXyZNAu03+v0A==",
+      "version": "0.14.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dp-services-ctl/-/dp-services-ctl-0.14.0-dev.1.tgz",
+      "integrity": "sha512-x8gQpxs+sWXvhbrrI2GGJf8hesskVl5N0hud/2t4WazRUjN3WaJNe6BS02rwkthy3OENK+yz5ABh7WUy2o514A==",
       "dev": true,
       "requires": {
-        "@dashevo/dapi-client": "~0.13.0",
+        "@dashevo/dapi-client": "~0.14.0-dev.4",
         "@dashevo/dashd-rpc": "^2.0.0",
         "aws-sdk": "^2.382.0",
         "axios": "^0.19.0",
@@ -490,19 +436,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "abstract-leveldown": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      }
     },
     "acorn": {
       "version": "6.4.1",
@@ -1120,12 +1053,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "buffer-reverse": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
-      "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A=",
-      "dev": true
-    },
     "bytebuffer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
@@ -1519,12 +1446,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1678,16 +1599,6 @@
       "dev": true,
       "requires": {
         "strip-bom": "^3.0.0"
-      }
-    },
-    "deferred-leveldown": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
       }
     },
     "define-properties": {
@@ -1982,15 +1893,6 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "requires": {
-        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -3182,12 +3084,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-      "dev": true
-    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -3510,12 +3406,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -3909,67 +3799,6 @@
         "invert-kv": "^1.0.0"
       }
     },
-    "level-concat-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
-      "dev": true
-    },
-    "level-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-      "dev": true,
-      "requires": {
-        "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "level-supports": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-      "dev": true,
-      "requires": {
-        "xtend": "^4.0.2"
-      }
-    },
-    "levelup": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-      "dev": true,
-      "requires": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      }
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4047,6 +3876,12 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
+    "lodash.sample": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.sample/-/lodash.sample-4.2.1.tgz",
+      "integrity": "sha1-XkKRsMdT+hq+sKq4+ynfG2bwf20=",
+      "dev": true
+    },
     "lodash.set": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
@@ -4062,19 +3897,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "lowdb": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
-      "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.3",
-        "is-promise": "^2.1.0",
-        "lodash": "4",
-        "pify": "^3.0.0",
-        "steno": "^0.4.1"
-      }
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -4099,12 +3921,6 @@
           "dev": true
         }
       }
-    },
-    "ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
-      "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
@@ -4139,31 +3955,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "memdown": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "~5.0.0",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-          "dev": true,
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
       }
     },
     "memory-pager": {
@@ -5340,12 +5131,6 @@
         "long": "^4.0.0"
       }
     },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -5467,12 +5252,6 @@
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -6123,15 +5902,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-    },
-    "steno": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
-      "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.3"
-      }
     },
     "stream-shift": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,16 +87,6 @@
       "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
       "dev": true
     },
-    "@babel/polyfill": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.1.tgz",
-      "integrity": "sha512-TviueJ4PBW5p48ra8IMtLXVkDucrlOZAIZ+EXqS3Ot4eukHbWiqcn7DcqpA1k5PcKtmJ4Xl9xwdv6yQvvcA+3g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
@@ -160,39 +150,17 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "0.13.0-dev.3",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.13.0-dev.3.tgz",
-      "integrity": "sha512-OR+YapplmoO+qjqRGF3Z/ajLqdBF1QWl3r+V6hoZSmxJtc44ltGZ042id/DNRL7NWsYM/9SLHOQM6FuUeOJDvQ==",
+      "version": "github:dashevo/dapi-client#a2631c52ec917ded4e90d8b59c31096ca38337d0",
+      "from": "github:dashevo/dapi-client#rewrite-from-the-scratch",
       "dev": true,
       "requires": {
-        "@babel/polyfill": "^7.8.3",
         "@dashevo/dapi-grpc": "~0.13.0-dev.4",
-        "@dashevo/dash-spv": "^1.1.6",
-        "@dashevo/dashcore-lib": "~0.18.0",
-        "@dashevo/dpp": "~0.12.0",
+        "@dashevo/dashcore-lib": "^0.18.1",
         "axios": "^0.19.2",
         "cbor": "^5.0.1",
-        "lodash": "^4.17.15",
-        "lowdb": "^1.0.0"
+        "lodash.sample": "^4.2.1"
       },
       "dependencies": {
-        "@dashevo/dpp": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.12.1.tgz",
-          "integrity": "sha512-NNIF5lq2bNh0lwFcMrEPYLtBp5G1YayFQBIiykTrgs8uf7zHtIgHBdr4/Rsf+D4Aw6/hgOrD7NH/YFmX9uBZVw==",
-          "dev": true,
-          "requires": {
-            "@apidevtools/json-schema-ref-parser": "^8.0.0",
-            "@dashevo/dashcore-lib": "~0.18.0",
-            "ajv": "^6.12.0",
-            "bs58": "^4.0.1",
-            "cbor": "^5.0.1",
-            "lodash.get": "^4.4.2",
-            "lodash.mergewith": "^4.6.2",
-            "lodash.set": "^4.3.2",
-            "multihashes": "^0.4.19"
-          }
-        },
         "cbor": {
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.2.tgz",
@@ -215,53 +183,6 @@
         "grpc": "^1.24.2",
         "grpc-web": "^1.0.6",
         "protobufjs": "^6.8.8"
-      }
-    },
-    "@dashevo/dark-gravity-wave": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dark-gravity-wave/-/dark-gravity-wave-1.1.1.tgz",
-      "integrity": "sha512-rt0PzGzqplqERWVIMLlBxm4mJqjFTYNUFRhIccbfaF/MDyd0/585krGOWIhe0Sis9XQNA/FJlxxRjtPXIcyyCg==",
-      "dev": true
-    },
-    "@dashevo/dash-spv": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-1.1.6.tgz",
-      "integrity": "sha512-pAZlwN4UJkht68zSq7MmqMZIHcvuah69UT7KM6RBeGrSEPaw1wxiz772tJ3Q/Px4FOHf3Uwc63ylOe7Vnbk1qA==",
-      "dev": true,
-      "requires": {
-        "@dashevo/dark-gravity-wave": "^1.1.1",
-        "@dashevo/dash-util": "^2.0.3",
-        "@dashevo/dashcore-lib": "^0.17.4",
-        "levelup": "^4.0.1",
-        "memdown": "^3.0.0"
-      },
-      "dependencies": {
-        "@dashevo/dashcore-lib": {
-          "version": "0.17.12",
-          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
-          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
-          "dev": true,
-          "requires": {
-            "@dashevo/x11-hash-js": "^1.0.2",
-            "bloom-filter": "^0.2.0",
-            "bn.js": "=4.11.8",
-            "bs58": "=4.0.1",
-            "elliptic": "=6.4.1",
-            "inherits": "=2.0.1",
-            "lodash": "^4.17.15",
-            "unorm": "^1.4.1"
-          }
-        }
-      }
-    },
-    "@dashevo/dash-util": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-util/-/dash-util-2.0.3.tgz",
-      "integrity": "sha512-fnc76NYVBhuTLhuUVidnV9sKSsMxmkxkhUOjiD/ny6Ipyo+qxwKeFAn8SvdVzlEpflNA613B+hsxmTBBGazl4A==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.6.4",
-        "buffer-reverse": "^1.0.1"
       }
     },
     "@dashevo/dashcore-lib": {
@@ -297,12 +218,11 @@
       }
     },
     "@dashevo/dp-services-ctl": {
-      "version": "0.13.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dp-services-ctl/-/dp-services-ctl-0.13.0-dev.1.tgz",
-      "integrity": "sha512-V2VT2MllixoSiwwCmKId3NUHHY7cR5jYrQvX+bMlsYzkIrhLkttNUsvKOVSHzTl19/O5kek4Kcu5sLDBOC+SCQ==",
+      "version": "github:dashevo/js-dp-services-ctl#a572caace8492985a2135296c931b7dd4b219b0a",
+      "from": "github:dashevo/js-dp-services-ctl#new-dapi-client",
       "dev": true,
       "requires": {
-        "@dashevo/dapi-client": "~0.13.0-dev.2",
+        "@dashevo/dapi-client": "github:dashevo/dapi-client#rewrite-from-the-scratch",
         "@dashevo/dashd-rpc": "^2.0.0",
         "@dashevo/drive-grpc": "~0.3.0",
         "aws-sdk": "^2.382.0",
@@ -531,19 +451,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
-    },
-    "abstract-leveldown": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      }
     },
     "acorn": {
       "version": "7.2.0",
@@ -819,12 +726,12 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.683.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.683.0.tgz",
-      "integrity": "sha512-mi1175pJMbQhCWhBEQ5ccQ3SDE+SJzbapuAQtcb7tdLLV7dPKf4zQXhpqK1uG0dysm8NhsNtgxwA2diYOKWlTg==",
+      "version": "2.689.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.689.0.tgz",
+      "integrity": "sha512-l9kbgZtIbR9dux4JHoxZ3vDWAfGtp34KpDDf5cwYHC5jDTTJoe6XhBBlEDSruwKh1+5DONpSZWNVhDZ6E02ojg==",
       "dev": true,
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
         "jmespath": "0.15.0",
@@ -836,9 +743,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -1171,12 +1078,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
-    "buffer-reverse": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
-      "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A=",
       "dev": true
     },
     "bytebuffer": {
@@ -1595,12 +1496,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1755,24 +1650,6 @@
       "dev": true,
       "requires": {
         "strip-bom": "^3.0.0"
-      }
-    },
-    "deferred-leveldown": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
-        }
       }
     },
     "define-properties": {
@@ -2082,15 +1959,6 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "requires": {
-        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -3651,12 +3519,6 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
-    "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-      "dev": true
-    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -4012,12 +3874,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -4408,73 +4264,6 @@
         "invert-kv": "^1.0.0"
       }
     },
-    "level-concat-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
-      "dev": true
-    },
-    "level-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-      "dev": true,
-      "requires": {
-        "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "level-supports": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-      "dev": true,
-      "requires": {
-        "xtend": "^4.0.2"
-      }
-    },
-    "levelup": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-      "dev": true,
-      "requires": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      }
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4552,6 +4341,12 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
+    "lodash.sample": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.sample/-/lodash.sample-4.2.1.tgz",
+      "integrity": "sha1-XkKRsMdT+hq+sKq4+ynfG2bwf20=",
+      "dev": true
+    },
     "lodash.set": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
@@ -4568,19 +4363,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "lowdb": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
-      "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.3",
-        "is-promise": "^2.1.0",
-        "lodash": "4",
-        "pify": "^3.0.0",
-        "steno": "^0.4.1"
-      }
-    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -4596,12 +4378,6 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
-    },
-    "ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
-      "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
@@ -4636,37 +4412,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "memdown": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "~5.0.0",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-          "dev": true,
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
       }
     },
     "memory-pager": {
@@ -4868,9 +4613,9 @@
       "dev": true
     },
     "mongodb": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.7.tgz",
-      "integrity": "sha512-lMtleRT+vIgY/JhhTn1nyGwnSMmJkJELp+4ZbrjctrnBxuLbj6rmLuJFz8W2xUzUqWmqoyVxJLYuC58ZKpcTYQ==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.8.tgz",
+      "integrity": "sha512-jz7mR58z66JKL8Px4ZY+FXbgB7d0a0hEGCT7kw8iye46/gsqPrOEpZOswwJ2BQlfzsrCLKdsF9UcaUfGVN2HrQ==",
       "dev": true,
       "requires": {
         "bl": "^2.2.0",
@@ -5765,12 +5510,6 @@
         "long": "^4.0.0"
       }
     },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -5910,12 +5649,6 @@
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -6562,15 +6295,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-    },
-    "steno": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
-      "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.3"
-      }
     },
     "stream-shift": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "zeromq": "^5.2.0"
   },
   "devDependencies": {
-    "@dashevo/dapi-client": "~0.13.0-dev.3",
-    "@dashevo/dp-services-ctl": "~0.13.0-dev.1",
+    "@dashevo/dapi-client": "dashevo/dapi-client#rewrite-from-the-scratch",
+    "@dashevo/dp-services-ctl": "dashevo/js-dp-services-ctl#new-dapi-client",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "zeromq": "^5.2.0"
   },
   "devDependencies": {
-    "@dashevo/dapi-client": "~0.13.0",
-    "@dashevo/dp-services-ctl": "~0.13.1",
+    "@dashevo/dapi-client": "~0.14.0-dev.4",
+    "@dashevo/dp-services-ctl": "~0.14.0-dev.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "zeromq": "^5.2.0"
   },
   "devDependencies": {
-    "@dashevo/dapi-client": "~0.14.0-dev.4",
+    "@dashevo/dapi-client": "^0.14.0-dev.5",
     "@dashevo/dp-services-ctl": "~0.14.0-dev.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/test/functional/grpcServer/handlers/core/getBlockHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/core/getBlockHandlerFactory.spec.js
@@ -38,7 +38,7 @@ describe('getBlockHandlerFactory', function main() {
   });
 
   it('should get block by hash', async () => {
-    const blockBinary = await dapiClient.getBlockByHash(blockHash);
+    const blockBinary = await dapiClient.core.getBlockByHash(blockHash);
 
     expect(blockBinary).to.be.an.instanceof(Buffer);
     const block = new Block(blockBinary);
@@ -47,7 +47,7 @@ describe('getBlockHandlerFactory', function main() {
   });
 
   it('should get block by height', async () => {
-    const blockBinary = await dapiClient.getBlockByHeight(blockHeight);
+    const blockBinary = await dapiClient.core.getBlockByHeight(blockHeight);
 
     expect(blockBinary).to.be.an.instanceof(Buffer);
     const block = new Block(blockBinary);
@@ -57,7 +57,7 @@ describe('getBlockHandlerFactory', function main() {
 
   it('should respond with an invalid argument error if the block was not found', async () => {
     try {
-      await dapiClient.getBlockByHeight(100000000);
+      await dapiClient.core.getBlockByHeight(100000000);
 
       expect.fail('Should throw an invalid argument error');
     } catch (e) {

--- a/test/functional/grpcServer/handlers/core/getStatusHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/core/getStatusHandlerFactory.spec.js
@@ -29,7 +29,7 @@ describe('getStatusHandlerFactory', function main() {
   });
 
   it('should return status', async () => {
-    const result = await dapiClient.getStatus();
+    const result = await dapiClient.core.getStatus();
 
     expect(result).to.have.a.property('coreVersion');
     expect(result).to.have.a.property('protocolVersion');

--- a/test/functional/grpcServer/handlers/core/getTransactionHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/core/getTransactionHandlerFactory.spec.js
@@ -34,7 +34,7 @@ describe('getTransactionHandlerFactor', function main() {
 
     await coreAPI.generateToAddress(1000, fromAddress);
 
-    const { items: unspent } = await dapiClient.getUTXO(fromAddress);
+    const { items: unspent } = await dapiClient.core.getUTXO(fromAddress);
 
     const amount = 10000;
 
@@ -54,7 +54,7 @@ describe('getTransactionHandlerFactor', function main() {
   });
 
   it('should respond with a transaction by it\'s ID', async () => {
-    const result = await dapiClient.getTransaction(transactionId);
+    const result = await dapiClient.core.getTransaction(transactionId);
     const receivedTx = new Transaction(Buffer.from(result));
     expect(receivedTx.toString('hex')).to.deep.equal(transaction.serialize());
   });
@@ -62,7 +62,7 @@ describe('getTransactionHandlerFactor', function main() {
   it('should respond with null if transaction was not found', async () => {
     const nonExistentId = Buffer.alloc(32).toString('hex');
 
-    const result = await dapiClient.getTransaction(nonExistentId);
+    const result = await dapiClient.core.getTransaction(nonExistentId);
 
     expect(result).to.be.null();
   });

--- a/test/functional/grpcServer/handlers/core/sendTransactionHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/core/sendTransactionHandlerFactory.spec.js
@@ -56,7 +56,10 @@ describe('sendTransactionHandlerFactory', function main() {
   it('should sent transaction and return transaction ID', async () => {
     const options = {};
 
-    const result = await dapiClient.sendTransaction(Buffer.from(transaction.serialize(), 'hex'), options);
+    const result = await dapiClient.core.broadcastTransaction(
+      Buffer.from(transaction.serialize(), 'hex'),
+      options,
+    );
 
     expect(result).to.be.a('string');
   });

--- a/test/functional/grpcServer/handlers/platform/getDataContractHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/platform/getDataContractHandlerFactory.spec.js
@@ -92,10 +92,10 @@ describe('getDataContractHandlerFactory', function main() {
     dataContractCreateTransition.sign(identity.getPublicKeyById(publicKeyId), privateKey);
 
     // Create Identity
-    await dapiClient.applyStateTransition(identityCreateTransition);
+    await dapiClient.platform.broadcastStateTransition(identityCreateTransition.serialize());
 
     // Create Data Contract
-    await dapiClient.applyStateTransition(dataContractCreateTransition);
+    await dapiClient.platform.broadcastStateTransition(dataContractCreateTransition.serialize());
   });
 
   after(async () => {
@@ -103,7 +103,7 @@ describe('getDataContractHandlerFactory', function main() {
   });
 
   it('should fetch created data contract', async () => {
-    const serializedDataContract = await dapiClient.getDataContract(
+    const serializedDataContract = await dapiClient.platform.getDataContract(
       dataContract.getId(),
     );
 
@@ -118,7 +118,7 @@ describe('getDataContractHandlerFactory', function main() {
   });
 
   it('should respond with null if data contract not found', async () => {
-    const serializedDataContract = await dapiClient.getDataContract(
+    const serializedDataContract = await dapiClient.platform.getDataContract(
       'unknownId',
     );
 

--- a/test/functional/grpcServer/handlers/platform/getDocumentsHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/platform/getDocumentsHandlerFactory.spec.js
@@ -98,7 +98,7 @@ describe('getDocumentsHandlerFactory', function main() {
 
     accumulatedFee += identityCreateTransition.calculateFee();
 
-    await dapiClient.applyStateTransition(identityCreateTransition);
+    await dapiClient.platform.broadcastStateTransition(identityCreateTransition.serialize());
 
     dataContract = getDataContractFixture(identity.getId());
 
@@ -107,7 +107,7 @@ describe('getDocumentsHandlerFactory', function main() {
 
     accumulatedFee += dataContractStateTransition.calculateFee();
 
-    await dapiClient.applyStateTransition(dataContractStateTransition);
+    await dapiClient.platform.broadcastStateTransition(dataContractStateTransition.serialize());
   });
 
   after(async () => {
@@ -128,9 +128,9 @@ describe('getDocumentsHandlerFactory', function main() {
 
     accumulatedFee += documentTransition.calculateFee();
 
-    await dapiClient.applyStateTransition(documentTransition);
+    await dapiClient.platform.broadcastStateTransition(documentTransition.serialize());
 
-    const [documentBuffer] = await dapiClient.getDocuments(dataContract.getId(), 'niceDocument', {});
+    const [documentBuffer] = await dapiClient.platform.getDocuments(dataContract.getId(), 'niceDocument', {});
 
     const receivedDocument = await dpp.document.createFromSerialized(
       documentBuffer, { skipValidation: true },
@@ -152,7 +152,7 @@ describe('getDocumentsHandlerFactory', function main() {
     documentTransition.sign(identity.getPublicKeyById(publicKeyId), identityPrivateKey);
 
     try {
-      await dapiClient.applyStateTransition(documentTransition);
+      await dapiClient.platform.broadcastStateTransition(documentTransition.serialize());
       expect.fail('Error was not thrown');
     } catch (e) {
       expect(e.code).to.equal(GrpcErrorCodes.FAILED_PRECONDITION);

--- a/test/functional/grpcServer/handlers/platform/getIdentityByFirstPublicKeyHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/platform/getIdentityByFirstPublicKeyHandlerFactory.spec.js
@@ -85,7 +85,7 @@ describe('getIdentityByFirstPublicKeyHandlerFactory', function main() {
     identityCreateTransition = dpp.identity.createIdentityCreateTransition(identity);
     identityCreateTransition.signByPrivateKey(privateKey);
 
-    await dapiClient.applyStateTransition(identityCreateTransition);
+    await dapiClient.platform.broadcastStateTransition(identityCreateTransition.serialize());
   });
 
   after(async () => {
@@ -95,7 +95,7 @@ describe('getIdentityByFirstPublicKeyHandlerFactory', function main() {
   it('should fetch created identity', async () => {
     const publicKeyHash = identity.getPublicKeyById(0).hash();
 
-    const serializedIdentity = await dapiClient.getIdentityByFirstPublicKey(
+    const serializedIdentity = await dapiClient.platform.getIdentityByFirstPublicKey(
       publicKeyHash,
     );
 
@@ -114,7 +114,7 @@ describe('getIdentityByFirstPublicKeyHandlerFactory', function main() {
 
   it('should respond with NOT_FOUND error if identity not found', async () => {
     const publicKeyHash = Buffer.alloc(10).toString('hex');
-    const serializedIdentity = await dapiClient.getIdentityByFirstPublicKey(
+    const serializedIdentity = await dapiClient.platform.getIdentityByFirstPublicKey(
       publicKeyHash,
     );
 

--- a/test/functional/grpcServer/handlers/platform/getIdentityHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/platform/getIdentityHandlerFactory.spec.js
@@ -85,7 +85,7 @@ describe('getIdentityHandlerFactory', function main() {
     identityCreateTransition = dpp.identity.createIdentityCreateTransition(identity);
     identityCreateTransition.signByPrivateKey(privateKey);
 
-    await dapiClient.applyStateTransition(identityCreateTransition);
+    await dapiClient.platform.broadcastStateTransition(identityCreateTransition.serialize());
   });
 
   after(async () => {
@@ -93,7 +93,7 @@ describe('getIdentityHandlerFactory', function main() {
   });
 
   it('should fetch created identity', async () => {
-    const serializedIdentity = await dapiClient.getIdentity(
+    const serializedIdentity = await dapiClient.platform.getIdentity(
       identityCreateTransition.getIdentityId(),
     );
 
@@ -111,7 +111,7 @@ describe('getIdentityHandlerFactory', function main() {
   });
 
   it('should respond with NOT_FOUND error if identity not found', async () => {
-    const serializedIdentity = await dapiClient.getIdentity('unknownId');
+    const serializedIdentity = await dapiClient.platform.getIdentity('unknownId');
 
     expect(serializedIdentity).to.be.null();
   });

--- a/test/functional/grpcServer/handlers/platform/getIdentityIdByFirstPublicKeyHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/platform/getIdentityIdByFirstPublicKeyHandlerFactory.spec.js
@@ -81,7 +81,7 @@ describe('getIdentityIdByFirstPublicKeyHandlerFactory', function main() {
     identityCreateTransition = dpp.identity.createIdentityCreateTransition(identity);
     identityCreateTransition.signByPrivateKey(privateKey);
 
-    await dapiClient.applyStateTransition(identityCreateTransition);
+    await dapiClient.platform.broadcastStateTransition(identityCreateTransition.serialize());
   });
 
   after(async () => {
@@ -91,7 +91,7 @@ describe('getIdentityIdByFirstPublicKeyHandlerFactory', function main() {
   it('should fetch created identity', async () => {
     const publicKeyHash = identity.getPublicKeyById(0).hash();
 
-    const identityId = await dapiClient.getIdentityIdByFirstPublicKey(
+    const identityId = await dapiClient.platform.getIdentityIdByFirstPublicKey(
       publicKeyHash,
     );
 
@@ -102,7 +102,7 @@ describe('getIdentityIdByFirstPublicKeyHandlerFactory', function main() {
 
   it('should respond with NOT_FOUND error if identity not found', async () => {
     const publicKeyHash = Buffer.alloc(10).toString('hex');
-    const serializedIdentity = await dapiClient.getIdentityIdByFirstPublicKey(
+    const serializedIdentity = await dapiClient.platform.getIdentityIdByFirstPublicKey(
       publicKeyHash,
     );
 

--- a/test/functional/grpcServer/handlers/platform/topUpIdentity.spec.js
+++ b/test/functional/grpcServer/handlers/platform/topUpIdentity.spec.js
@@ -93,7 +93,7 @@ describe('topUpIdentity', function main() {
     identityCreateTransition = dpp.identity.createIdentityCreateTransition(identity);
     identityCreateTransition.signByPrivateKey(privateKey);
 
-    await dapiClient.applyStateTransition(identityCreateTransition);
+    await dapiClient.platform.broadcastStateTransition(identityCreateTransition.serialize());
   });
 
   after(async () => {
@@ -126,9 +126,9 @@ describe('topUpIdentity', function main() {
     );
     identityTopUpTransition.signByPrivateKey(privateKey);
 
-    await dapiClient.applyStateTransition(identityTopUpTransition);
+    await dapiClient.platform.broadcastStateTransition(identityTopUpTransition.serialize());
 
-    const serializedIdentity = await dapiClient.getIdentity(
+    const serializedIdentity = await dapiClient.platform.getIdentity(
       identityCreateTransition.getIdentityId(),
     );
 
@@ -166,7 +166,7 @@ describe('topUpIdentity', function main() {
     identityTopUpTransition.signByPrivateKey(privateKey);
 
     try {
-      await dapiClient.applyStateTransition(identityTopUpTransition);
+      await dapiClient.platform.broadcastStateTransition(identityTopUpTransition.serialize());
 
       expect.fail('Should fail with error');
     } catch (e) {
@@ -174,7 +174,7 @@ describe('topUpIdentity', function main() {
       expect(e.details).to.equal('State Transition is invalid');
     }
 
-    const serializedIdentity = await dapiClient.getIdentity(
+    const serializedIdentity = await dapiClient.platform.getIdentity(
       identityCreateTransition.getIdentityId(),
     );
 

--- a/test/functional/grpcServer/handlers/platform/validateIdentityPublicKeyUniqueness.spec.js
+++ b/test/functional/grpcServer/handlers/platform/validateIdentityPublicKeyUniqueness.spec.js
@@ -100,7 +100,7 @@ describe('validateIdentityPublicKeyUniqueness', function main() {
     identityCreateTransition = dpp.identity.createIdentityCreateTransition(identity);
     identityCreateTransition.signByPrivateKey(privateKey);
 
-    await dapiClient.applyStateTransition(identityCreateTransition);
+    await dapiClient.platform.broadcastStateTransition(identityCreateTransition.serialize());
   });
 
   after(async () => {
@@ -121,7 +121,7 @@ describe('validateIdentityPublicKeyUniqueness', function main() {
     identityCreateTransition.signByPrivateKey(privateKey);
 
     try {
-      await dapiClient.applyStateTransition(identityCreateTransition);
+      await dapiClient.platform.broadcastStateTransition(identityCreateTransition.serialize());
       expect.fail('Error was not thrown');
     } catch (e) {
       const [error] = JSON.parse(e.metadata.get('errors')[0]);

--- a/test/functional/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
+++ b/test/functional/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
@@ -106,7 +106,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', function main() {
 
     const bloomFilterObject = bloomFilter.toObject();
 
-    const stream = await dapiClient.subscribeToTransactionsWithProofs(
+    const stream = await dapiClient.core.subscribeToTransactionsWithProofs(
       {
         vData: new Uint8Array(bloomFilterObject.vData),
         nHashFuncs: bloomFilterObject.nHashFuncs,
@@ -177,7 +177,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', function main() {
 
     const bloomFilterObject = bloomFilter.toObject();
 
-    const stream = await dapiClient.subscribeToTransactionsWithProofs(
+    const stream = await dapiClient.core.subscribeToTransactionsWithProofs(
       {
         vData: new Uint8Array(bloomFilterObject.vData),
         nHashFuncs: bloomFilterObject.nHashFuncs,
@@ -280,7 +280,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', function main() {
 
     const bloomFilterObject = bloomFilter.toObject();
 
-    const stream = await dapiClient.subscribeToTransactionsWithProofs(
+    const stream = await dapiClient.core.subscribeToTransactionsWithProofs(
       {
         vData: new Uint8Array(bloomFilterObject.vData),
         nHashFuncs: bloomFilterObject.nHashFuncs,
@@ -443,7 +443,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', function main() {
     await coreAPI.sendRawTransaction(transaction.serialize());
 
     // Connect to the stream
-    const stream = await dapiClient.subscribeToTransactionsWithProofs(
+    const stream = await dapiClient.core.subscribeToTransactionsWithProofs(
       {
         vData: new Uint8Array(bloomFilterObject.vData),
         nHashFuncs: bloomFilterObject.nHashFuncs,

--- a/test/functional/rpcServer/commands/getAddressSummary.spec.js
+++ b/test/functional/rpcServer/commands/getAddressSummary.spec.js
@@ -31,7 +31,7 @@ describe('rpcServer', function main() {
   });
 
   it('should return address summary', async () => {
-    const result = await dapiClient.getAddressSummary(address);
+    const result = await dapiClient.core.getAddressSummary(address);
 
     expect(result).to.be.an('object');
     expect(result.addrStr).to.equal(address);
@@ -41,11 +41,11 @@ describe('rpcServer', function main() {
     address = 'Xh7nD4vTUYAxy8GV7t1k8Er9ZKmxRBDcL';
 
     try {
-      await dapiClient.getAddressSummary(address);
+      await dapiClient.core.getAddressSummary(address);
 
       expect.fail('should throw an error');
     } catch (e) {
-      expect(e.name).to.equal('RPCError');
+      expect(e.name).to.equal('JsonRpcError');
       expect(e.message).contains('Invalid address');
     }
   });

--- a/test/functional/rpcServer/commands/getBlockHash.spec.js
+++ b/test/functional/rpcServer/commands/getBlockHash.spec.js
@@ -35,7 +35,7 @@ describe('rpcServer', function main() {
 
     it('should get block hash by height', async () => {
       const height = blocksNumber - 10;
-      const hash = await dapiClient.getBlockHash(height);
+      const hash = await dapiClient.core.getBlockHash(height);
 
       expect(hash).to.be.a('string');
     });
@@ -44,11 +44,11 @@ describe('rpcServer', function main() {
       const height = blocksNumber * 3;
 
       try {
-        await dapiClient.getBlockHash(height);
+        await dapiClient.core.getBlockHash(height);
 
         expect.fail('Should throw error');
       } catch (e) {
-        expect(e.name).to.equal('RPCError');
+        expect(e.name).to.equal('JsonRpcError');
         expect(e.message).contains('Block height out of range');
       }
     });


### PR DESCRIPTION
## Issue being fixed or feature implemented
Functional tests needed to be updated to work with the new version of DAPI client. 


## What was done?
Old DAPI client methods in functional tests were replaced with the new ones


## How Has This Been Tested?
With functional tests 


## Breaking Changes
DAPI client methods have been changed.
Need to use the new version of js-dp-services-ctl.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
