### PR TITLE
fix: internal error when `fromBlockHeight` submitted as 0  to `subscribeToTransactionsWithProofs`

### DIFF
--- a/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
+++ b/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
@@ -89,10 +89,6 @@ function subscribeToTransactionsWithProofsHandlerFactory(
     const fromBlockHeight = request.getFromBlockHeight();
     const count = request.getCount();
 
-    if (fromBlockHeight === 0 && fromBlockHash === '') {
-      throw new InvalidArgumentGrpcError('minimum value for `fromBlockHeight` is 1');
-    }
-
     // Create a new bloom filter emitter when client connects
     let filter;
     try {
@@ -105,7 +101,11 @@ function subscribeToTransactionsWithProofsHandlerFactory(
 
     let blockHash = fromBlockHash;
 
-    if (blockHash.length === 0) {
+    if (blockHash === '') {
+      if (fromBlockHeight === 0) {
+        throw new InvalidArgumentGrpcError('minimum value for `fromBlockHeight` is 1');
+      }
+
       const bestHeight = await coreAPI.getBestBlockHeight();
 
       if (fromBlockHeight > bestHeight) {

--- a/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
+++ b/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
@@ -89,7 +89,7 @@ function subscribeToTransactionsWithProofsHandlerFactory(
     const fromBlockHeight = request.getFromBlockHeight();
     const count = request.getCount();
 
-    if (fromBlockHeight === 0) {
+    if (fromBlockHeight === 0 && fromBlockHash === '') {
       throw new InvalidArgumentGrpcError('minimum value for `fromBlockHeight` is 1');
     }
 

--- a/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
+++ b/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
@@ -89,6 +89,10 @@ function subscribeToTransactionsWithProofsHandlerFactory(
     const fromBlockHeight = request.getFromBlockHeight();
     const count = request.getCount();
 
+    if (fromBlockHeight === 0) {
+      throw new InvalidArgumentGrpcError('minimum value for `fromBlockHeight` is 1');
+    }
+
     // Create a new bloom filter emitter when client connects
     let filter;
     try {

--- a/test/unit/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
+++ b/test/unit/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
@@ -129,6 +129,31 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
     }
   });
 
+  it('should respond with error if `fromBlockHeight is 0', async () => {
+    const bloomFilterMessage = new BloomFilter();
+
+    bloomFilterMessage.setVData(new Uint8Array());
+    bloomFilterMessage.setNTweak(1000);
+    bloomFilterMessage.setNFlags(100);
+    bloomFilterMessage.setNHashFuncs(10);
+
+    const request = new TransactionsWithProofsRequest();
+
+    request.setFromBlockHeight(0);
+    request.setBloomFilter(bloomFilterMessage);
+
+    call.request = request;
+
+    try {
+      await subscribeToTransactionsWithProofsHandler(call);
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(InvalidArgumentGrpcError);
+      expect(e.getMessage()).to.equal('minimum value for `fromBlockHeight` is 1');
+      expect(call.write).to.not.have.been.called();
+      expect(call.end).to.not.have.been.called();
+    }
+  });
+
   it('should subscribe to new transactions from 0 height if both fromBlockHash and fromBlockHeight are not specified', async function it() {
     const hash = 'someHash';
     const hashHex = Buffer.from('someHash').toString('hex');

--- a/test/unit/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
+++ b/test/unit/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
@@ -129,7 +129,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
     }
   });
 
-  it('should respond with error if `fromBlockHeight is 0', async () => {
+  it('should respond with error if `fromBlockHeight is 0 and `fromBlockHash` is not set', async () => {
     const bloomFilterMessage = new BloomFilter();
 
     bloomFilterMessage.setVData(new Uint8Array());
@@ -146,6 +146,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
 
     try {
       await subscribeToTransactionsWithProofsHandler(call);
+      expect.fail('Error was not thrown');
     } catch (e) {
       expect(e).to.be.an.instanceOf(InvalidArgumentGrpcError);
       expect(e.getMessage()).to.equal('minimum value for `fromBlockHeight` is 1');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal error is thrown when `options.fromBlockHeight` is submitted as `0` to `subscribeToTransactionsWithProofs`


## What was done?
<!--- Describe your changes in detail -->
Added assertions for `fromBlockHeight` value to be more then `0`


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
