### PR TITLE
feat!: rename sendTransaction and applyStateTransition to broadcast

### DIFF
--- a/lib/grpcServer/handlers/core/broadcastTransactionHandlerFactory.js
+++ b/lib/grpcServer/handlers/core/broadcastTransactionHandlerFactory.js
@@ -1,5 +1,5 @@
 const {
-  SendTransactionResponse,
+  BroadcastTransactionResponse,
 } = require('@dashevo/dapi-grpc');
 
 
@@ -15,15 +15,15 @@ const { Transaction } = require('@dashevo/dashcore-lib');
 
 /**
  * @param {InsightAPI} insightAPI
- * @returns {sendTransactionHandler}
+ * @returns {broadcastTransactionHandler}
  */
-function sendTransactionHandlerFactory(insightAPI) {
+function broadcastTransactionHandlerFactory(insightAPI) {
   /**
-   * @typedef sendTransactionHandler
+   * @typedef broadcastTransactionHandler
    * @param {Object} call
-   * @returns {Promise<SendTransactionResponse>}
+   * @returns {Promise<BroadcastTransactionResponse>}
    */
-  async function sendTransactionHandler(call) {
+  async function broadcastTransactionHandler(call) {
     const { request } = call;
 
     const serializedTransactionBinary = request.getTransaction();
@@ -60,13 +60,13 @@ function sendTransactionHandlerFactory(insightAPI) {
       throw e;
     }
 
-    const response = new SendTransactionResponse();
+    const response = new BroadcastTransactionResponse();
     response.setTransactionId(transactionId);
 
     return response;
   }
 
-  return sendTransactionHandler;
+  return broadcastTransactionHandler;
 }
 
-module.exports = sendTransactionHandlerFactory;
+module.exports = broadcastTransactionHandlerFactory;

--- a/lib/grpcServer/handlers/core/coreHandlersFactory.js
+++ b/lib/grpcServer/handlers/core/coreHandlersFactory.js
@@ -14,13 +14,13 @@ const {
 } = require('@dashevo/grpc-common');
 
 const {
-  SendTransactionRequest,
+  BroadcastTransactionRequest,
   GetTransactionRequest,
   GetStatusRequest,
   GetBlockRequest,
   pbjs: {
-    SendTransactionRequest: PBJSSendTransactionRequest,
-    SendTransactionResponse: PBJSSendTransactionResponse,
+    BroadcastTransactionRequest: PBJSBroadcastTransactionRequest,
+    BroadcastTransactionResponse: PBJSBroadcastTransactionResponse,
     GetTransactionRequest: PBJSGetTransactionRequest,
     GetTransactionResponse: PBJSGetTransactionResponse,
     GetStatusRequest: PBJSGetStatusRequest,
@@ -41,8 +41,8 @@ const getStatusHandlerFactory = require(
 const getTransactionHandlerFactory = require(
   './getTransactionHandlerFactory',
 );
-const sendTransactionHandlerFactory = require(
-  './sendTransactionHandlerFactory',
+const broadcastTransactionHandlerFactory = require(
+  './broadcastTransactionHandlerFactory',
 );
 
 /**
@@ -91,24 +91,24 @@ function coreHandlersFactory(insightAPI) {
     wrapInErrorHandler(getTransactionHandler),
   );
 
-  // sendTransaction
-  const sendTransactionHandler = sendTransactionHandlerFactory(insightAPI);
-  const wrappedSendTransaction = jsonToProtobufHandlerWrapper(
+  // broadcastTransaction
+  const broadcastTransactionHandler = broadcastTransactionHandlerFactory(insightAPI);
+  const wrappedBroadcastTransaction = jsonToProtobufHandlerWrapper(
     jsonToProtobufFactory(
-      SendTransactionRequest,
-      PBJSSendTransactionRequest,
+      BroadcastTransactionRequest,
+      PBJSBroadcastTransactionRequest,
     ),
     protobufToJsonFactory(
-      PBJSSendTransactionResponse,
+      PBJSBroadcastTransactionResponse,
     ),
-    wrapInErrorHandler(sendTransactionHandler),
+    wrapInErrorHandler(broadcastTransactionHandler),
   );
 
   return {
     getBlock: wrappedGetBlock,
     getStatus: wrappedGetStatus,
     getTransaction: wrappedGetTransaction,
-    sendTransaction: wrappedSendTransaction,
+    broadcastTransaction: wrappedBroadcastTransaction,
   };
 }
 

--- a/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -7,7 +7,7 @@ const {
 } = require('@dashevo/grpc-common');
 
 const {
-  ApplyStateTransitionResponse,
+  BroadcastStateTransitionResponse,
 } = require('@dashevo/dapi-grpc');
 
 const AbciResponseError = require('../../../errors/AbciResponseError');
@@ -16,17 +16,17 @@ const AbciResponseError = require('../../../errors/AbciResponseError');
  * @param {jaysonClient} rpcClient
  * @param {handleAbciResponseError} handleAbciResponseError
  *
- * @returns {applyStateTransitionHandler}
+ * @returns {broadcastStateTransitionHandler}
  */
-function applyStateTransitionHandlerFactory(rpcClient, handleAbciResponseError) {
+function broadcastStateTransitionHandlerFactory(rpcClient, handleAbciResponseError) {
   /**
-   * @typedef applyStateTransitionHandler
+   * @typedef broadcastStateTransitionHandler
    *
    * @param {Object} call
    *
-   * @return {Promise<ApplyStateTransitionResponse>}
+   * @return {Promise<BroadcastStateTransitionResponse>}
    */
-  async function applyStateTransitionHandler(call) {
+  async function broadcastStateTransitionHandler(call) {
     const { request } = call;
     const stByteArray = request.getStateTransition();
 
@@ -63,10 +63,10 @@ function applyStateTransitionHandlerFactory(rpcClient, handleAbciResponseError) 
       );
     }
 
-    return new ApplyStateTransitionResponse();
+    return new BroadcastStateTransitionResponse();
   }
 
-  return applyStateTransitionHandler;
+  return broadcastStateTransitionHandler;
 }
 
-module.exports = applyStateTransitionHandlerFactory;
+module.exports = broadcastStateTransitionHandlerFactory;

--- a/lib/grpcServer/handlers/platform/platformHandlersFactory.js
+++ b/lib/grpcServer/handlers/platform/platformHandlersFactory.js
@@ -14,15 +14,15 @@ const {
 } = require('@dashevo/grpc-common');
 
 const {
-  ApplyStateTransitionRequest,
+  ApplyStateTransitionRequest: BroadcastStateTransitionRequest,
   GetIdentityRequest,
   GetDataContractRequest,
   GetDocumentsRequest,
   GetIdentityByFirstPublicKeyRequest,
   GetIdentityIdByFirstPublicKeyRequest,
   pbjs: {
-    ApplyStateTransitionRequest: PBJSApplyStateTransitionRequest,
-    ApplyStateTransitionResponse: PBJSApplyStateTransitionResponse,
+    ApplyStateTransitionRequest: PBJSBroadcastStateTransitionRequest,
+    ApplyStateTransitionResponse: PBJSBroadcastStateTransitionResponse,
     GetIdentityRequest: PBJSGetIdentityRequest,
     GetIdentityResponse: PBJSGetIdentityResponse,
     GetDataContractRequest: PBJSGetDataContractRequest,
@@ -43,8 +43,8 @@ const handleAbciResponseError = require('../handleAbciResponseError');
 const getIdentityHandlerFactory = require(
   './getIdentityHandlerFactory',
 );
-const applyStateTransitionHandlerFactory = require(
-  './applyStateTransitionHandlerFactory',
+const broadcastStateTransitionHandlerFactory = require(
+  './broadcastStateTransitionHandlerFactory',
 );
 const getDocumentsHandlerFactory = require(
   './getDocumentsHandlerFactory',
@@ -67,21 +67,21 @@ const getIdentityIdByFirstPublicKeyHandlerFactory = require(
 function platformHandlersFactory(rpcClient, driveStateRepository) {
   const wrapInErrorHandler = wrapInErrorHandlerFactory(log);
 
-  // applyStateTransition
-  const applyStateTransitionHandler = applyStateTransitionHandlerFactory(
+  // broadcastStateTransition
+  const broadcastStateTransitionHandler = broadcastStateTransitionHandlerFactory(
     rpcClient,
     handleAbciResponseError,
   );
 
-  const wrappedApplyStateTransition = jsonToProtobufHandlerWrapper(
+  const wrappedBroadcastStateTransition = jsonToProtobufHandlerWrapper(
     jsonToProtobufFactory(
-      ApplyStateTransitionRequest,
-      PBJSApplyStateTransitionRequest,
+      BroadcastStateTransitionRequest,
+      PBJSBroadcastStateTransitionRequest,
     ),
     protobufToJsonFactory(
-      PBJSApplyStateTransitionResponse,
+      PBJSBroadcastStateTransitionResponse,
     ),
-    wrapInErrorHandler(applyStateTransitionHandler),
+    wrapInErrorHandler(broadcastStateTransitionHandler),
   );
 
   // getIdentity
@@ -165,7 +165,7 @@ function platformHandlersFactory(rpcClient, driveStateRepository) {
   );
 
   return {
-    applyStateTransition: wrappedApplyStateTransition,
+    broadcastStateTransition: wrappedBroadcastStateTransition,
     getIdentity: wrappedGetIdentity,
     getDocuments: wrappedGetDocuments,
     getDataContract: wrappedGetDataContract,

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,9 +182,9 @@
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.14.0.tgz",
-      "integrity": "sha512-eMx9OF80uxHFHD3gZ1Yro5pLTpgTuNQiy0Kts3mRDIjVyqgMbthIeYVcyzOwARs6FJrJfX18QnQ4kUt9b1ILKQ==",
+      "version": "0.15.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.15.0-dev.1.tgz",
+      "integrity": "sha512-2yfLGF3UsVmYRfbKsTRqI9NbL+gS9zF0J5iypiqgeEK4foDRV3zfhwGBGorJq9SWdYc+n7AtVS1OhFICkstIkw==",
       "requires": {
         "@dashevo/grpc-common": "^0.3.0",
         "google-protobuf": "^3.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,15 +182,15 @@
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.13.0.tgz",
-      "integrity": "sha512-w6oyQsHO5/m56DNS9Z41qelJWhT9vh9AOE8tBzv6Zd5mI+wV+LhM95r9xwpb0x6CufXCK1K9kLkBOFuOp/C2Pg==",
+      "version": "0.15.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.15.0-dev.1.tgz",
+      "integrity": "sha512-2yfLGF3UsVmYRfbKsTRqI9NbL+gS9zF0J5iypiqgeEK4foDRV3zfhwGBGorJq9SWdYc+n7AtVS1OhFICkstIkw==",
       "requires": {
         "@dashevo/grpc-common": "^0.3.0",
-        "google-protobuf": "^3.8.0",
-        "grpc": "^1.24.2",
-        "grpc-web": "^1.0.6",
-        "protobufjs": "^6.8.8"
+        "google-protobuf": "^3.12.2",
+        "grpc": "^1.24.3",
+        "grpc-web": "^1.1.0",
+        "protobufjs": "^6.9.0"
       }
     },
     "@dashevo/dashcore-lib": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "all": true
   },
   "dependencies": {
-    "@dashevo/dapi-grpc": "~0.13.0",
+    "@dashevo/dapi-grpc": "~0.15.0-dev.1",
     "@dashevo/dashcore-lib": "~0.18.11",
     "@dashevo/dashd-rpc": "^2.0.0",
     "@dashevo/dpp": "~0.14.0-dev.4",

--- a/test/unit/grpcServer/handlers/core/broadcastTransactionHandlerFactory.js
+++ b/test/unit/grpcServer/handlers/core/broadcastTransactionHandlerFactory.js
@@ -9,20 +9,20 @@ const {
 const { Transaction } = require('@dashevo/dashcore-lib');
 
 const {
-  SendTransactionResponse,
+  BroadcastTransactionResponse,
 } = require('@dashevo/dapi-grpc');
 
-const sendTransactionHandlerFactory = require('../../../../../lib/grpcServer/handlers/core/sendTransactionHandlerFactory');
+const broadcastTransactionHandlerFactory = require('../../../../../lib/grpcServer/handlers/core/broadcastTransactionHandlerFactory');
 
 const GrpcCallMock = require('../../../../../lib/test/mock/GrpcCallMock');
 
-describe('sendTransactionHandlerFactory', () => {
+describe('broadcastTransactionHandlerFactory', () => {
   let call;
   let insightAPIMock;
   let request;
   let serializedTransaction;
   let transactionId;
-  let sendTransactionHandler;
+  let broadcastTransactionHandler;
 
   beforeEach(function beforeEach() {
     const rawTransaction = '0300000001086a3640a4a88a85d5720ecb69a93d0aef1cfa759d1242835e4abaf4168b924d000000006b483045022100ed608a9742913c94e057798297a6a96ed40c41dc61209e6887df51ea5755234802207f5733ef592f3df59bc6d39749ac5f1a771b32263ce16982b1aacc80ff1358cd012103323aa9dd83ba005b1b1e61b36cba27c2e0f64bacb57c34243fc7ef2751fff6edffffffff021027000000000000166a1481b21f3898087a0d1905140c7db8d7db00acd13954a09a3b000000001976a91481b21f3898087a0d1905140c7db8d7db00acd13988ac00000000';
@@ -41,13 +41,13 @@ describe('sendTransactionHandlerFactory', () => {
       sendTransaction: this.sinon.stub().resolves(transactionId),
     };
 
-    sendTransactionHandler = sendTransactionHandlerFactory(insightAPIMock);
+    broadcastTransactionHandler = broadcastTransactionHandlerFactory(insightAPIMock);
   });
 
   it('should return valid result', async () => {
-    const result = await sendTransactionHandler(call);
+    const result = await broadcastTransactionHandler(call);
 
-    expect(result).to.be.an.instanceOf(SendTransactionResponse);
+    expect(result).to.be.an.instanceOf(BroadcastTransactionResponse);
     expect(result.getTransactionId()).to.equal(transactionId);
     expect(insightAPIMock.sendTransaction).to.be.calledOnceWith(serializedTransaction.toString('hex'));
   });
@@ -57,7 +57,7 @@ describe('sendTransactionHandlerFactory', () => {
     request.getTransaction.returns(serializedTransaction);
 
     try {
-      await sendTransactionHandler(call);
+      await broadcastTransactionHandler(call);
 
       expect.fail('should thrown InvalidArgumentGrpcError error');
     } catch (e) {
@@ -72,7 +72,7 @@ describe('sendTransactionHandlerFactory', () => {
     request.getTransaction.returns(serializedTransaction);
 
     try {
-      await sendTransactionHandler(call);
+      await broadcastTransactionHandler(call);
 
       expect.fail('should thrown InvalidArgumentGrpcError error');
     } catch (e) {
@@ -87,7 +87,7 @@ describe('sendTransactionHandlerFactory', () => {
     request.getTransaction.returns(serializedTransaction);
 
     try {
-      await sendTransactionHandler(call);
+      await broadcastTransactionHandler(call);
 
       expect.fail('should thrown InvalidArgumentGrpcError error');
     } catch (e) {

--- a/test/unit/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/test/unit/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -7,7 +7,7 @@ const {
 } = require('@dashevo/grpc-common');
 
 const {
-  ApplyStateTransitionResponse,
+  BroadcastStateTransitionResponse,
 } = require('@dashevo/dapi-grpc');
 
 const DashPlatformProtocol = require('@dashevo/dpp');
@@ -15,14 +15,14 @@ const getDataContractFixture = require('@dashevo/dpp/lib/test/fixtures/getDataCo
 
 const GrpcCallMock = require('../../../../../lib/test/mock/GrpcCallMock');
 
-const applyStateTransitionHandlerFactory = require(
-  '../../../../../lib/grpcServer/handlers/platform/applyStateTransitionHandlerFactory',
+const broadcastStateTransitionHandlerFactory = require(
+  '../../../../../lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory',
 );
 
-describe('applyStateTransitionHandlerFactory', () => {
+describe('broadcastStateTransitionHandlerFactory', () => {
   let call;
   let rpcClientMock;
-  let applyStateTransitionHandler;
+  let broadcastStateTransitionHandler;
   let response;
   let stateTransitionFixture;
   let log;
@@ -69,7 +69,7 @@ describe('applyStateTransitionHandlerFactory', () => {
 
     handleAbciResponseErrorMock = this.sinon.stub();
 
-    applyStateTransitionHandler = applyStateTransitionHandlerFactory(
+    broadcastStateTransitionHandler = broadcastStateTransitionHandlerFactory(
       rpcClientMock,
       handleAbciResponseErrorMock,
     );
@@ -83,7 +83,7 @@ describe('applyStateTransitionHandlerFactory', () => {
     call.request.getStateTransition.returns(null);
 
     try {
-      await applyStateTransitionHandler(call);
+      await broadcastStateTransitionHandler(call);
 
       expect.fail('InvalidArgumentGrpcError was not thrown');
     } catch (e) {
@@ -95,11 +95,11 @@ describe('applyStateTransitionHandlerFactory', () => {
   });
 
   it('should return valid result', async () => {
-    const result = await applyStateTransitionHandler(call);
+    const result = await broadcastStateTransitionHandler(call);
 
     const tx = stateTransitionFixture.serialize().toString('base64');
 
-    expect(result).to.be.an.instanceOf(ApplyStateTransitionResponse);
+    expect(result).to.be.an.instanceOf(BroadcastStateTransitionResponse);
     expect(rpcClientMock.request).to.be.calledOnceWith('broadcast_tx_commit', { tx });
     expect(handleAbciResponseErrorMock).to.not.be.called();
   });
@@ -115,7 +115,7 @@ describe('applyStateTransitionHandlerFactory', () => {
     rpcClientMock.request.resolves(response);
 
     try {
-      await applyStateTransitionHandler(call);
+      await broadcastStateTransitionHandler(call);
 
       expect.fail('InternalGrpcError was not thrown');
     } catch (e) {
@@ -133,7 +133,7 @@ describe('applyStateTransitionHandlerFactory', () => {
     rpcClientMock.request.resolves(response);
 
     try {
-      await applyStateTransitionHandler(call);
+      await broadcastStateTransitionHandler(call);
 
       expect.fail('InternalGrpcError was not thrown');
     } catch (e) {
@@ -147,7 +147,7 @@ describe('applyStateTransitionHandlerFactory', () => {
     response.error = error;
 
     try {
-      await applyStateTransitionHandler(call);
+      await broadcastStateTransitionHandler(call);
     } catch (e) {
       expect(e.message).to.equal(error.message);
       expect(e.data).to.equal(error.data);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to more accurately name DAPI and DAPI gRPC endpoints we need to rename sendTransaction and applyStateTransition methods.

## What was done?
<!--- Describe your changes in detail -->
sendTransaction renamed to broadcastTransaction
applyStateTransition renamed to broadcastStateTransition
dapi-grpc updated to 0.15.0-dev.1

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
sendTransaction renamed to broadcastTransaction
applyStateTransition renamed to broadcastStateTransition

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
