### PR TITLE
chore(travis): update travis-ci-tools repo path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - npm ci
   - cp .env.example .env
   # Get the latest version of travis-ci-tools
-  - curl -s https://api.github.com/repos/jawid-h/travis-ci-tools/releases/latest | jq -r '.tarball_url' | xargs -I {} -n1 wget -O travis-ci-tools.tar.gz -q {}
+  - curl -s https://api.github.com/repos/dashevo/travis-ci-tools/releases/latest | jq -r '.tarball_url' | xargs -I {} -n1 wget -O travis-ci-tools.tar.gz -q {}
   - mkdir ~/travis-ci-tools && tar -C ~/travis-ci-tools -xvf travis-ci-tools.tar.gz
   - export CI_TOOLS_DIR="$(ls ~/travis-ci-tools)"
   - cd ~/travis-ci-tools/$CI_TOOLS_DIR


### PR DESCRIPTION
## Issue being fixed or feature implemented

We moved the travis-ci-tools from @jawid-h to our the local dashevo organisation. 
This PR modified the path to reflect that changes.

## What was done?
- chore: update travis-ci-tools repo path from jawid-h/travis-ci-tools to dashevo/travis-ci-tools

## How Has This Been Tested?

Automated travis tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone
