### PR TITLE
fix: 'count too big' error

### DIFF
--- a/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
+++ b/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
@@ -89,7 +89,7 @@ function subscribeToTransactionsWithProofsHandlerFactory(
 
     const fromBlockHash = Buffer.from(request.getFromBlockHash()).toString('hex');
     const fromBlockHeight = request.getFromBlockHeight();
-    const count = request.getCount();
+    let count = request.getCount();
 
     // Create a new bloom filter emitter when client connects
     let filter;
@@ -122,9 +122,13 @@ function subscribeToTransactionsWithProofsHandlerFactory(
       const bestBlockHeight = await coreAPI.getBestBlockHeight();
 
       if (block.height + count > bestBlockHeight + 1) {
-        throw new InvalidArgumentGrpcError(
-          'count is too big, could not fetch more than blockchain length',
-        );
+        // This code should throw an error 'count is too big',
+        // however at the time of writing height chain sync isn't yet implemented,
+        // so the client library doesn't know the exact height and
+        // mat pass count number larger than expected.
+        // This line should be converted to throwing an error once
+        // the header stream is implemented
+        count = bestBlockHeight - block.height;
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`count too big` error during the js client sync due to the fact that the client doesn't know the exact height becasue header chain sync is currently not supported via DAPI. Needs to be reverted back once header stream implemented

## What was done?
<!--- Describe your changes in detail -->
replaced the code that throws an error with a code that caps block.height+count to the best block height 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
