### PR TITLE
feat: throw GrpcError if state transaction was broadcasted twice

### DIFF
--- a/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -2,6 +2,7 @@ const {
   server: {
     error: {
       InvalidArgumentGrpcError,
+      FailedPreconditionGrpcError,
     },
   },
 } = require('@dashevo/grpc-common');
@@ -41,6 +42,10 @@ function broadcastStateTransitionHandlerFactory(rpcClient, handleAbciResponseErr
     const { result, error: jsonRpcError } = await rpcClient.request('broadcast_tx_commit', { tx });
 
     if (jsonRpcError) {
+      if (jsonRpcError.data === 'error on broadcastTxCommit: tx already exists in cache') {
+        throw new FailedPreconditionGrpcError(jsonRpcError.data, jsonRpcError);
+      }
+
       const error = new Error();
       Object.assign(error, jsonRpcError);
 

--- a/test/unit/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/test/unit/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -2,6 +2,7 @@ const {
   server: {
     error: {
       InvalidArgumentGrpcError,
+      FailedPreconditionGrpcError,
     },
   },
 } = require('@dashevo/grpc-common');
@@ -154,6 +155,23 @@ describe('broadcastStateTransitionHandlerFactory', () => {
       expect(e.message).to.equal(error.message);
       expect(e.data).to.equal(error.data);
       expect(e.code).to.equal(error.code);
+    }
+  });
+
+  it('should throw FailedPreconditionGrpcError if transaction was broadcasted twice', async () => {
+    const error = {
+      code: -32603,
+      message: 'Internal error',
+      data: 'error on broadcastTxCommit: tx already exists in cache',
+    };
+
+    response.error = error;
+
+    try {
+      await broadcastStateTransitionHandler(call);
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(FailedPreconditionGrpcError);
+      expect(e.getMessage()).to.equal(`Failed precondition: ${error.data}`);
     }
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If state transaction was broadcasted twice, we get Internal error

## What was done?
<!--- Describe your changes in detail -->
Fixed broadcastStateTransitionHandler to throw correct error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
