### PR TITLE
fix: cannot destructure property 'error' of 'result' as it is undefined

### DIFF
--- a/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -39,9 +39,9 @@ function broadcastStateTransitionHandlerFactory(rpcClient, handleAbciResponseErr
 
     const tx = Buffer.from(stByteArray).toString('base64');
 
-    const { result } = await rpcClient.request('broadcast_tx_sync', { tx });
+    const broadcastResult = await rpcClient.request('broadcast_tx_sync', { tx });
 
-    const { error: jsonRpcError } = result;
+    const { result, error: jsonRpcError } = broadcastResult;
 
     if (jsonRpcError) {
       if (jsonRpcError.data === 'tx already exists in cache') {

--- a/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -39,9 +39,7 @@ function broadcastStateTransitionHandlerFactory(rpcClient, handleAbciResponseErr
 
     const tx = Buffer.from(stByteArray).toString('base64');
 
-    const broadcastResult = await rpcClient.request('broadcast_tx_sync', { tx });
-
-    const { result, error: jsonRpcError } = broadcastResult;
+    const { result, error: jsonRpcError } = await rpcClient.request('broadcast_tx_sync', { tx });
 
     if (jsonRpcError) {
       if (jsonRpcError.data === 'tx already exists in cache') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed destructuring of broadcast_tx_sync response

## What was done?
<!--- Describe your changes in detail -->
Moved destructuring of broadcast_tx_sync response one level above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
