### PR TITLE
fix: `subscribeToTransactionsWithProofsHandler` misses transactions from mempool

### DIFF
--- a/lib/externalApis/dashcore/rpc.js
+++ b/lib/externalApis/dashcore/rpc.js
@@ -105,6 +105,16 @@ const getMempoolInfo = () => new Promise((resolve, reject) => {
   });
 });
 
+const getRawMemPool = verbose => new Promise((resolve, reject) => {
+  client.getrawmempool(verbose, (err, r) => {
+    if (err) {
+      reject(new DashCoreRpcError(err.message, null, err.code));
+    } else {
+      resolve(r.result);
+    }
+  });
+});
+
 const getMnListDiff = (baseBlockHash, blockHash) => new Promise((resolve, reject) => {
   client.protx(constants.DASHCORE_RPC_COMMANDS.protx.diff, baseBlockHash, blockHash, (err, r) => {
     if (err) {
@@ -329,4 +339,5 @@ module.exports = {
   getMerkleBlocks,
   getBlockchainInfo,
   getNetworkInfo,
+  getRawMemPool,
 };

--- a/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
+++ b/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
@@ -80,6 +80,7 @@ async function sendInstantLockResponse(call, instantLock) {
  * @param {BloomFilterEmitterCollection} bloomFilterEmitterCollection
  * @param {testFunction} testTransactionAgainstFilter
  * @param {CoreRpcClient} coreAPI
+ * @param {getMemPoolTransactions} getMemPoolTransactions
  * @return {subscribeToTransactionsWithProofsHandler}
  */
 function subscribeToTransactionsWithProofsHandlerFactory(
@@ -88,6 +89,7 @@ function subscribeToTransactionsWithProofsHandlerFactory(
   bloomFilterEmitterCollection,
   testTransactionAgainstFilter,
   coreAPI,
+  getMemPoolTransactions,
 ) {
   /**
    * @typedef subscribeToTransactionsWithProofsHandler
@@ -191,7 +193,13 @@ function subscribeToTransactionsWithProofsHandlerFactory(
       }
     }
 
+    // notify new txs listener that we've sent historical data
+    mediator.emit(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT);
+
     if (isNewTransactionsRequested) {
+      const memPoolTransactions = await getMemPoolTransactions(filter);
+      await sendTransactionsResponse(acknowledgingCall, memPoolTransactions);
+
       // new txs listener will send us unsent cached data back
       mediator.on(
         ProcessMediator.EVENTS.TRANSACTION,
@@ -214,8 +222,7 @@ function subscribeToTransactionsWithProofsHandlerFactory(
         },
       );
 
-      // notify new txs listener that we've sent historical data
-      mediator.emit(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT);
+      mediator.emit(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT);
     } else {
       // End stream if user asked only for historical data
       call.end();

--- a/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
+++ b/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
@@ -198,7 +198,9 @@ function subscribeToTransactionsWithProofsHandlerFactory(
 
     if (isNewTransactionsRequested) {
       const memPoolTransactions = await getMemPoolTransactions(filter);
-      await sendTransactionsResponse(acknowledgingCall, memPoolTransactions);
+      if (memPoolTransactions.length) {
+        await sendTransactionsResponse(acknowledgingCall, memPoolTransactions);
+      }
 
       // new txs listener will send us unsent cached data back
       mediator.on(

--- a/lib/transactionsFilter/ProcessMediator.js
+++ b/lib/transactionsFilter/ProcessMediator.js
@@ -9,6 +9,7 @@ ProcessMediator.EVENTS = {
   CLIENT_DISCONNECTED: 'clientDisconnected',
   HISTORICAL_BLOCK_SENT: 'historicalBlockSent',
   INSTANT_LOCK: 'instantLock',
+  MEMPOOL_DATA_SENT: 'memPoolDataSent',
 };
 
 module.exports = ProcessMediator;

--- a/lib/transactionsFilter/getMemPoolTransactionsFactory.js
+++ b/lib/transactionsFilter/getMemPoolTransactionsFactory.js
@@ -1,0 +1,32 @@
+const { Transaction } = require('@dashevo/dashcore-lib');
+
+/**
+ * @param {CoreRpcClient} coreAPI
+ * @param {testFunction} testTransactionsAgainstFilter
+ * @returns {getMemPoolTransactions}
+ */
+function getMemPoolTransactionsFactory(coreAPI, testTransactionsAgainstFilter) {
+  /**
+   * @typedef getMemPoolTransactions
+   * @param {BloomFilter} filter
+   * @returns {Promise<Transaction[]>}
+   */
+  async function getMemPoolTransactions(filter) {
+    const result = [];
+    const memPoolTransactionIds = await coreAPI.getRawMemPool(false);
+
+    for (const txId of memPoolTransactionIds) {
+      const rawTransaction = await coreAPI.getRawTransaction(txId);
+      const transaction = new Transaction(rawTransaction);
+      if (testTransactionsAgainstFilter(filter, transaction)) {
+        result.push(transaction);
+      }
+    }
+
+    return result;
+  }
+
+  return getMemPoolTransactions;
+}
+
+module.exports = getMemPoolTransactionsFactory;

--- a/lib/transactionsFilter/subscribeToNewTransactions.js
+++ b/lib/transactionsFilter/subscribeToNewTransactions.js
@@ -66,7 +66,7 @@ function subscribeToNewTransactions(
   // as new data continuously after that.
   //
   // This loop works because cache is populated from ZMQ events.
-  mediator.once(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT, async () => {
+  mediator.once(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT, async () => {
     while (isClientConnected) {
       const unsentTransactions = transactionsAndBlocksCache.getUnretrievedTransactions();
       unsentTransactions

--- a/lib/transactionsFilter/testRawTransactionAgainstFilterCollectionFactory.js
+++ b/lib/transactionsFilter/testRawTransactionAgainstFilterCollectionFactory.js
@@ -8,6 +8,7 @@ function testRawTransactionAgainstFilterCollectionFactory(bloomFilterEmitterColl
   /**
    * Test a raw transaction against bloom filter collection
    *
+   * @typedef testRawTransactionAgainstFilterCollection
    * @param {Buffer} rawTransaction
    */
   function testRawTransactionAgainstFilterCollection(rawTransaction) {

--- a/scripts/tx-filter-stream.js
+++ b/scripts/tx-filter-stream.js
@@ -48,6 +48,7 @@ const subscribeToTransactionsWithProofsHandlerFactory = require('../lib/grpcServ
 
 const subscribeToNewTransactions = require('../lib/transactionsFilter/subscribeToNewTransactions');
 const getHistoricalTransactionsIteratorFactory = require('../lib/transactionsFilter/getHistoricalTransactionsIteratorFactory');
+const getMemPoolTransactionsFactory = require('../lib/transactionsFilter/getMemPoolTransactionsFactory');
 
 async function main() {
   // Validate config
@@ -117,12 +118,18 @@ async function main() {
     dashCoreRpcClient,
   );
 
+  const getMemPoolTransactions = getMemPoolTransactionsFactory(
+    dashCoreRpcClient,
+    testTransactionsAgainstFilter,
+  );
+
   const subscribeToTransactionsWithProofsHandler = subscribeToTransactionsWithProofsHandlerFactory(
     getHistoricalTransactionsIterator,
     subscribeToNewTransactions,
     bloomFilterEmitterCollection,
     testTransactionsAgainstFilter,
     dashCoreRpcClient,
+    getMemPoolTransactions,
   );
 
   const wrappedSubscribeToTransactionsWithProofs = jsonToProtobufHandlerWrapper(

--- a/test/integration/transactionsFilter/subscribeToNewTransactions.spec.js
+++ b/test/integration/transactionsFilter/subscribeToNewTransactions.spec.js
@@ -162,7 +162,7 @@ describe('subscribeToNewTransactions', () => {
 
     bloomFilterEmitterCollection.emit('block', blocks[0]);
 
-    mediator.emit(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT);
+    mediator.emit(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT);
     mediator.emit(ProcessMediator.EVENTS.CLIENT_DISCONNECTED);
 
     expect(receivedTransactions).to.deep.equal([
@@ -210,7 +210,7 @@ describe('subscribeToNewTransactions', () => {
 
     bloomFilterEmitterCollection.emit('block', blocks[0]);
 
-    mediator.emit(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT);
+    mediator.emit(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT);
     mediator.emit(ProcessMediator.EVENTS.CLIENT_DISCONNECTED);
 
     expect(receivedTransactions).to.deep.equal([
@@ -267,7 +267,7 @@ describe('subscribeToNewTransactions', () => {
 
     mediator.emit(ProcessMediator.EVENTS.HISTORICAL_BLOCK_SENT, blocks[0].hash);
 
-    mediator.emit(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT);
+    mediator.emit(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT);
     mediator.emit(ProcessMediator.EVENTS.CLIENT_DISCONNECTED);
 
     expect(receivedTransactions).to.deep.equal([
@@ -331,7 +331,7 @@ describe('subscribeToNewTransactions', () => {
 
     mediator.emit(ProcessMediator.EVENTS.HISTORICAL_BLOCK_SENT, blocks[0].hash);
 
-    mediator.emit(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT);
+    mediator.emit(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT);
     mediator.emit(ProcessMediator.EVENTS.CLIENT_DISCONNECTED);
 
     expect(receivedTransactions).to.deep.equal([
@@ -413,7 +413,7 @@ describe('subscribeToNewTransactions', () => {
 
     mediator.emit(ProcessMediator.EVENTS.HISTORICAL_BLOCK_SENT, blocks[0].hash);
 
-    mediator.emit(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT);
+    mediator.emit(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT);
     mediator.emit(ProcessMediator.EVENTS.CLIENT_DISCONNECTED);
 
     expect(receivedTransactions).to.deep.equal([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the client was reconnected to `subscribeToTransactionsWithProofs` or it was connected after transaction was emitted, there will be no instantLock event emitted.

## What was done?
<!--- Describe your changes in detail -->
Scan mempool for new transactions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
