### PR TITLE
fix: subscribeToNewTransactions doesn't emit instant lock in some cases 

### DIFF
--- a/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
+++ b/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
@@ -121,38 +121,8 @@ function subscribeToTransactionsWithProofsHandlerFactory(
 
     const isNewTransactionsRequested = count === 0;
 
-    let blockHash = fromBlockHash;
-
-    if (blockHash === '') {
-      if (fromBlockHeight === 0) {
-        throw new InvalidArgumentGrpcError('minimum value for `fromBlockHeight` is 1');
-      }
-
-      const bestHeight = await coreAPI.getBestBlockHeight();
-
-      if (fromBlockHeight > bestHeight) {
-        throw new InvalidArgumentGrpcError('fromBlockHeight is bigger than block count');
-      }
-
-      blockHash = await coreAPI.getBlockHash(fromBlockHeight);
-    }
-
-    if (count > 0) {
-      const block = await coreAPI.getBlock(blockHash);
-      const bestBlockHeight = await coreAPI.getBestBlockHeight();
-
-      if (block.height + count > bestBlockHeight + 1) {
-        // This code should throw an error 'count is too big',
-        // however at the time of writing height chain sync isn't yet implemented,
-        // so the client library doesn't know the exact height and
-        // mat pass count number larger than expected.
-        // This line should be converted to throwing an error once
-        // the header stream is implemented
-        count = bestBlockHeight - block.height;
-      }
-    }
-
     const acknowledgingCall = new AcknowledgingWritable(call);
+
     const mediator = new ProcessMediator();
 
     if (isNewTransactionsRequested) {
@@ -164,12 +134,39 @@ function subscribeToTransactionsWithProofsHandlerFactory(
       );
     }
 
+    // If block height is specified instead of block hash, we obtain block hash by block height
+    let blockHash = fromBlockHash;
+
+    if (blockHash === '') {
+      if (fromBlockHeight === 0) {
+        throw new InvalidArgumentGrpcError('minimum value for `fromBlockHeight` is 1');
+      }
+
+      // we don't need to check bestBlockHeight because getBlockHash throws
+      // an error in case of wrong height
+      blockHash = await coreAPI.getBlockHash(fromBlockHeight);
+    }
+
     let historicalCount = count;
-    if (subscribeToNewTransactions) {
+
+    if (count > 0 || isNewTransactionsRequested) {
       const block = await coreAPI.getBlock(blockHash);
       const bestBlockHeight = await coreAPI.getBestBlockHeight();
 
-      historicalCount = bestBlockHeight - block.height + 1;
+      if (count > 0 && block.height + count > bestBlockHeight + 1) {
+        // This code should throw an error 'count is too big',
+        // however at the time of writing height chain sync isn't yet implemented,
+        // so the client library doesn't know the exact height and
+        // mat pass count number larger than expected.
+        // This line should be converted to throwing an error once
+        // the header stream is implemented
+        count = bestBlockHeight - block.height;
+        historicalCount = count;
+      }
+
+      if (isNewTransactionsRequested) {
+        historicalCount = bestBlockHeight - block.height + 1;
+      }
     }
 
     const historicalDataIterator = getHistoricalTransactionsIterator(
@@ -197,10 +194,11 @@ function subscribeToTransactionsWithProofsHandlerFactory(
     mediator.emit(ProcessMediator.EVENTS.HISTORICAL_DATA_SENT);
 
     if (isNewTransactionsRequested) {
-      const memPoolTransactions = await getMemPoolTransactions(filter);
-      if (memPoolTransactions.length) {
-        await sendTransactionsResponse(acknowledgingCall, memPoolTransactions);
-      }
+      // Read and test transactions from mempool
+      const memPoolTransactions = await getMemPoolTransactions();
+      memPoolTransactions.forEach(
+        bloomFilterEmitterCollection.test.bind(bloomFilterEmitterCollection),
+      );
 
       // new txs listener will send us unsent cached data back
       mediator.on(

--- a/lib/transactionsFilter/TransactionHashesCache.js
+++ b/lib/transactionsFilter/TransactionHashesCache.js
@@ -32,7 +32,7 @@ class TransactionHashesCache {
    *
    * @param {Transaction} transaction
    *
-   * @returns {void}
+   * @returns {boolean} - false if already exists
    */
   addTransaction(transaction) {
     const isAdded = this.transactions
@@ -49,6 +49,8 @@ class TransactionHashesCache {
     if (!this.isInInstantLockCache(transaction.hash)) {
       this.transactionHashesMap[transaction.hash] = this.blocksProcessed;
     }
+
+    return !isAdded;
   }
 
   /**

--- a/lib/transactionsFilter/emitInstantLockToFilterCollectionFactory.js
+++ b/lib/transactionsFilter/emitInstantLockToFilterCollectionFactory.js
@@ -2,7 +2,7 @@ const { Transaction, InstantLock } = require('@dashevo/dashcore-lib');
 
 /**
  * @param {BloomFilterEmitterCollection} bloomFilterEmitterCollection
- * @return {testBlockEventToFilterCollection}
+ * @return {emitInstantLockToFilterCollection}
  */
 function emitInstantLockToFilterCollectionFactory(bloomFilterEmitterCollection) {
   /**
@@ -10,15 +10,21 @@ function emitInstantLockToFilterCollectionFactory(bloomFilterEmitterCollection) 
    *
    * @param {Buffer} rawTransactionLock
    */
-  function testBlockEventToFilterCollection(rawTransactionLock) {
-    const txBuffer = new Transaction().fromBuffer(rawTransactionLock).toBuffer();
-    const txLockBuffer = rawTransactionLock.slice(txBuffer.length, rawTransactionLock.length);
-    const transactionLock = new InstantLock(txLockBuffer);
+  function emitInstantLockToFilterCollection(rawTransactionLock) {
+    const transaction = new Transaction().fromBuffer(rawTransactionLock);
+    const txBuffer = transaction.toBuffer();
 
-    bloomFilterEmitterCollection.emit('instantLock', transactionLock);
+    const txLockBuffer = rawTransactionLock.slice(txBuffer.length, rawTransactionLock.length);
+
+    const instantLock = new InstantLock(txLockBuffer);
+
+    bloomFilterEmitterCollection.emit('instantLock', {
+      transaction,
+      instantLock,
+    });
   }
 
-  return testBlockEventToFilterCollection;
+  return emitInstantLockToFilterCollection;
 }
 
 module.exports = emitInstantLockToFilterCollectionFactory;

--- a/lib/transactionsFilter/getMemPoolTransactionsFactory.js
+++ b/lib/transactionsFilter/getMemPoolTransactionsFactory.js
@@ -2,25 +2,21 @@ const { Transaction } = require('@dashevo/dashcore-lib');
 
 /**
  * @param {CoreRpcClient} coreAPI
- * @param {testFunction} testTransactionsAgainstFilter
  * @returns {getMemPoolTransactions}
  */
-function getMemPoolTransactionsFactory(coreAPI, testTransactionsAgainstFilter) {
+function getMemPoolTransactionsFactory(coreAPI) {
   /**
    * @typedef getMemPoolTransactions
-   * @param {BloomFilter} filter
    * @returns {Promise<Transaction[]>}
    */
-  async function getMemPoolTransactions(filter) {
+  async function getMemPoolTransactions() {
     const result = [];
     const memPoolTransactionIds = await coreAPI.getRawMemPool(false);
 
     for (const txId of memPoolTransactionIds) {
       const rawTransaction = await coreAPI.getRawTransaction(txId);
       const transaction = new Transaction(rawTransaction);
-      if (testTransactionsAgainstFilter(filter, transaction)) {
-        result.push(transaction);
-      }
+      result.push(transaction);
     }
 
     return result;

--- a/lib/transactionsFilter/getMemPoolTransactionsFactory.js
+++ b/lib/transactionsFilter/getMemPoolTransactionsFactory.js
@@ -15,6 +15,7 @@ function getMemPoolTransactionsFactory(coreAPI) {
 
     for (const txId of memPoolTransactionIds) {
       const rawTransaction = await coreAPI.getRawTransaction(txId);
+
       const transaction = new Transaction(rawTransaction);
       result.push(transaction);
     }

--- a/lib/transactionsFilter/subscribeToNewTransactions.js
+++ b/lib/transactionsFilter/subscribeToNewTransactions.js
@@ -65,11 +65,7 @@ function subscribeToNewTransactions(
     transactionsAndBlocksCache.removeDataByBlockHash(blockHash);
   });
 
-  // Receive an event when all historical data (is any) is sent to the user,
-  // so we can run a loop until client is disconnected and send cached as well
-  // as new data continuously after that.
-  //
-  // This loop works because cache is populated from ZMQ events.
+  // Receive an event when all historical and mempool data (is any) is sent to the user.
   mediator.once(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT, async () => {
     // When mempool transactions are sent we start to send
     // instant locks right away instead of collecting them
@@ -99,6 +95,13 @@ function subscribeToNewTransactions(
         .forEach(merkleBlock => mediator.emit(ProcessMediator.EVENTS.MERKLE_BLOCK, merkleBlock));
 
       await wait(50);
+    }
+
+    if (unretrievedInstantLocks.size > 0) {
+      unretrievedInstantLocks.forEach((instantLock) => {
+        mediator.emit(ProcessMediator.EVENTS.INSTANT_LOCK, instantLock);
+      });
+      unretrievedInstantLocks.clear();
     }
   });
 

--- a/lib/transactionsFilter/subscribeToNewTransactions.js
+++ b/lib/transactionsFilter/subscribeToNewTransactions.js
@@ -23,6 +23,7 @@ function subscribeToNewTransactions(
   const transactionsAndBlocksCache = new TransactionHashesCache();
 
   let isClientConnected = true;
+  const unretrievedInstantLocks = new Map();
 
   // store and emit transaction or a locked transaction hash when they match the bloom filter
   filterEmitter.on('match', (transaction) => {
@@ -43,16 +44,19 @@ function subscribeToNewTransactions(
     transactionsAndBlocksCache.addBlock(block);
   });
 
-  filterEmitter.on('instantLock', (instantLock) => {
-    const isTransactionInWaitingList = transactionsAndBlocksCache
-      .isInInstantLockCache(instantLock.txid);
-
-    if (isTransactionInWaitingList) {
-      transactionsAndBlocksCache
-        .removeTransactionHashFromInstantSendLockWaitingList(instantLock.txid);
-      mediator.emit(ProcessMediator.EVENTS.INSTANT_LOCK, instantLock);
+  // Collect instant locked transactions and locks
+  // while we sending historical and mempool data
+  const preMempoolSentInstantLockListener = ({ instantLock, transaction }) => {
+    if (!testTransactionAgainstFilter(filter, transaction)) {
+      return;
     }
-  });
+
+    transactionsAndBlocksCache.addTransaction(transaction);
+
+    unretrievedInstantLocks.set(instantLock.txid, instantLock);
+  };
+
+  filterEmitter.on('instantLock', preMempoolSentInstantLockListener);
 
   // Receive an event when a historical block is sent to user,
   // so we can update our cache to an actual state,
@@ -67,6 +71,24 @@ function subscribeToNewTransactions(
   //
   // This loop works because cache is populated from ZMQ events.
   mediator.once(ProcessMediator.EVENTS.MEMPOOL_DATA_SENT, async () => {
+    // When mempool transactions are sent we start to send
+    // instant locks right away instead of collecting them
+    filterEmitter.removeListener('instantLock', preMempoolSentInstantLockListener);
+
+    filterEmitter.on('instantLock', ({ instantLock }) => {
+      const isTransactionInWaitingList = transactionsAndBlocksCache
+        .isInInstantLockCache(instantLock.txid);
+
+      if (isTransactionInWaitingList) {
+        transactionsAndBlocksCache
+          .removeTransactionHashFromInstantSendLockWaitingList(instantLock.txid);
+        mediator.emit(ProcessMediator.EVENTS.INSTANT_LOCK, instantLock);
+      }
+    });
+
+    // Run a loop until client is disconnected and send cached as well
+    // as new data (through the cache) continuously after that.
+    // Cache is populated from ZMQ events.
     while (isClientConnected) {
       const unsentTransactions = transactionsAndBlocksCache.getUnretrievedTransactions();
       unsentTransactions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some rare cases, instant locks are not emitted in subscribeToNewTransactions endpoints, which leads to timeouts errors in dashmate

## What was done?
<!--- Describe your changes in detail -->
Fixed `subscribeToNewTransactions` endpoint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running Dashmate

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
