### PR TITLE
fix: `prove` options was set as a string

### DIFF
--- a/lib/externalApis/drive/DriveClient.js
+++ b/lib/externalApis/drive/DriveClient.js
@@ -32,9 +32,7 @@ class DriveClient {
       data: encodedData.toString('hex'),
     };
 
-    if (prove === true) {
-      requestOptions.prove = 'true';
-    }
+    requestOptions.prove = prove;
 
     const { result, error } = await this.client.request(
       'abci_query',

--- a/test/unit/externalApis/drive/DriveClient.js
+++ b/test/unit/externalApis/drive/DriveClient.js
@@ -101,7 +101,7 @@ describe('DriveClient', () => {
       expect(drive.client.request).to.have.been.calledOnceWithExactly('abci_query', {
         path: '/dataContracts',
         data: cbor.encode({ id: contractId }).toString('hex'), // cbor encoded empty object
-        prove: 'true',
+        prove: true,
       });
       expect(result).to.be.deep.equal(buffer);
     });
@@ -133,7 +133,7 @@ describe('DriveClient', () => {
       expect(drive.client.request).to.have.been.calledOnceWithExactly('abci_query', {
         path: '/dataContracts/documents',
         data: cbor.encode({ ...options, contractId, type }).toString('hex'), // cbor encoded empty object
-        prove: 'true',
+        prove: true,
       });
       expect(result).to.be.deep.equal(buffer);
     });
@@ -158,7 +158,8 @@ describe('DriveClient', () => {
 
       expect(drive.client.request).to.have.been.calledOnceWithExactly('abci_query', {
         path: '/identities',
-        data: cbor.encode({ id: identityId }).toString('hex'), // cbor encoded empty object
+        data: cbor.encode({ id: identityId }).toString('hex'),
+        prove: false, // cbor encoded empty object
       });
       expect(result).to.be.deep.equal(buffer);
     });
@@ -186,7 +187,7 @@ describe('DriveClient', () => {
       expect(drive.client.request).to.have.been.calledOnceWithExactly('abci_query', {
         path: '/identities/by-public-key-hash',
         data: cbor.encode({ publicKeyHashes }).toString('hex'),
-        prove: 'true',
+        prove: true,
       });
       expect(result).to.be.deep.equal(buffer);
     });
@@ -213,7 +214,7 @@ describe('DriveClient', () => {
       expect(drive.client.request).to.have.been.calledOnceWithExactly('abci_query', {
         path: '/identities/by-public-key-hash/id',
         data: cbor.encode({ publicKeyHashes }).toString('hex'),
-        prove: 'true',
+        prove: true,
       });
       expect(result).to.be.deep.equal(buffer);
     });
@@ -246,6 +247,7 @@ describe('DriveClient', () => {
           identityIds,
           dataContractIds,
         }).toString('hex'),
+        prove: false,
       });
 
       expect(result).to.be.deep.equal({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`prove` options was sent to `Tenderdash` as a `string` rather than `boolean`

## What was done?
<!--- Describe your changes in detail -->
- changed the type

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local setup

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
