### PR TITLE
feat: respond with Drive's error data in metadata

### DIFF
--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,4 +1,4 @@
-DRIVE_BRANCH=feat/grpc-error-codes
-DASHMATE_BRANCH=error-codes
-TEST_SUITE_BRANCH=error-codes
-#SDK_BRANCH=error-codes
+DRIVE_BRANCH=bring-back-drive-errors
+DASHMATE_BRANCH=convenient-errors
+TEST_SUITE_BRANCH=convenient-errors
+SDK_BRANCH=convenient-errors

--- a/lib/dpp/DriveStateRepository.js
+++ b/lib/dpp/DriveStateRepository.js
@@ -33,6 +33,7 @@ class DriveStateRepository {
 
     return this.dpp.dataContract.createFromBuffer(
       Buffer.from(dataContractResponse.getDataContract()),
+      { skipValidation: true },
     );
   }
 }

--- a/lib/grpcServer/handlers/createGrpcErrorFromDriveResponse.js
+++ b/lib/grpcServer/handlers/createGrpcErrorFromDriveResponse.js
@@ -1,4 +1,5 @@
 const cbor = require('cbor');
+
 const {
   server: {
     error: {
@@ -18,6 +19,30 @@ const AlreadyExistsGrpcError = require('@dashevo/grpc-common/lib/server/error/Al
 const createConsensusError = require('@dashevo/dpp/lib/errors/consensus/createConsensusError');
 
 /**
+ * @param {Object} data
+ * @returns {{"drive-error-data-bin": Buffer}||{}}
+ */
+function createRawMetadata(data) {
+  if (Object.keys(data).length === 0) {
+    return {};
+  }
+
+  return {
+    'drive-error-data-bin': cbor.encode(data),
+  };
+}
+
+const COMMON_ERROR_CLASSES = {
+  [GrpcErrorCodes.INVALID_ARGUMENT]: InvalidArgumentGrpcError,
+  [GrpcErrorCodes.DEADLINE_EXCEEDED]: DeadlineExceededGrpcError,
+  [GrpcErrorCodes.NOT_FOUND]: NotFoundGrpcError,
+  [GrpcErrorCodes.ALREADY_EXISTS]: AlreadyExistsGrpcError,
+  [GrpcErrorCodes.RESOURCE_EXHAUSTED]: ResourceExhaustedGrpcError,
+  [GrpcErrorCodes.FAILED_PRECONDITION]: FailedPreconditionGrpcError,
+  [GrpcErrorCodes.UNAVAILABLE]: UnavailableGrpcError,
+};
+
+/**
  * @typedef createGrpcErrorFromDriveResponse
  * @param {number} code
  * @param {string} info
@@ -28,68 +53,79 @@ function createGrpcErrorFromDriveResponse(code, info) {
     return new InternalGrpcError(new Error('Drive’s error code is empty'));
   }
 
-  const decodedInfo = info ? cbor.decode(Buffer.from(info, 'base64')) : undefined;
+  const decodedInfo = info ? cbor.decode(Buffer.from(info, 'base64')) : { };
 
-  // eslint-disable-next-line default-case
-  switch (code) {
-    case GrpcErrorCodes.INVALID_ARGUMENT:
-      return new InvalidArgumentGrpcError(decodedInfo.message, decodedInfo.metadata);
-    case GrpcErrorCodes.DEADLINE_EXCEEDED:
-      return new DeadlineExceededGrpcError(decodedInfo.message, decodedInfo.metadata);
-    case GrpcErrorCodes.NOT_FOUND:
-      return new NotFoundGrpcError(decodedInfo.message, decodedInfo.metadata);
-    case GrpcErrorCodes.ALREADY_EXISTS:
-      return new AlreadyExistsGrpcError(decodedInfo.message, decodedInfo.metadata);
-    case GrpcErrorCodes.RESOURCE_EXHAUSTED:
-      return new ResourceExhaustedGrpcError(decodedInfo.message, decodedInfo.metadata);
-    case GrpcErrorCodes.FAILED_PRECONDITION:
-      return new FailedPreconditionGrpcError(decodedInfo.message, decodedInfo.metadata);
-    case GrpcErrorCodes.INTERNAL: {
-      const error = new Error(decodedInfo.message);
-      error.stack = decodedInfo.metadata.stack;
-
-      delete decodedInfo.metadata.stack;
-
-      return new InternalGrpcError(error, decodedInfo.metadata);
+  // gRPC error codes
+  if (code <= 16) {
+    const CommonErrorClass = COMMON_ERROR_CLASSES[code.toString()];
+    if (CommonErrorClass) {
+      return new CommonErrorClass(
+        decodedInfo.message,
+        createRawMetadata(decodedInfo.data),
+      );
     }
-    case GrpcErrorCodes.UNAVAILABLE:
-      return new UnavailableGrpcError(decodedInfo.message, decodedInfo.metadata);
-    case GrpcErrorCodes.CANCELLED:
-    case GrpcErrorCodes.UNKNOWN:
-    case GrpcErrorCodes.UNAUTHENTICATED:
-    case GrpcErrorCodes.DATA_LOSS:
-    case GrpcErrorCodes.UNIMPLEMENTED:
-    case GrpcErrorCodes.OUT_OF_RANGE:
-    case GrpcErrorCodes.ABORTED:
-    case GrpcErrorCodes.PERMISSION_DENIED:
-      return new GrpcError(code, decodedInfo.message, decodedInfo.metadata);
+
+    // Restore stack for internal error
+    if (code === GrpcErrorCodes.INTERNAL) {
+      const error = new Error(decodedInfo.message);
+      error.stack = decodedInfo.data.stack;
+
+      delete decodedInfo.data.stack;
+
+      return new InternalGrpcError(error, createRawMetadata(decodedInfo.data));
+    }
+
+    return new GrpcError(
+      code,
+      decodedInfo.message,
+      createRawMetadata(decodedInfo.data),
+    );
   }
 
+  // Undefined Drive and DAPI errors
   if (code >= 17 && code < 1000) {
-    return new GrpcError(GrpcErrorCodes.UNKNOWN, decodedInfo.message, decodedInfo.metadata);
+    return new GrpcError(
+      GrpcErrorCodes.UNKNOWN,
+      decodedInfo.message,
+      createRawMetadata(decodedInfo.data),
+    );
   }
 
+  // DPP errors
   if (code >= 1000 && code < 5000) {
-    const consensusError = createConsensusError(code, decodedInfo || []);
+    const consensusError = createConsensusError(code, decodedInfo.data.arguments || []);
 
     // Basic
     if (code >= 1000 && code < 2000) {
-      return new InvalidArgumentGrpcError(consensusError.message, { code });
+      return new InvalidArgumentGrpcError(
+        consensusError.message,
+        { code, ...createRawMetadata(decodedInfo.data) },
+      );
     }
 
     // Signature
     if (code >= 2000 && code < 3000) {
-      return new GrpcError(GrpcErrorCodes.UNAUTHENTICATED, consensusError.message, { code });
+      return new GrpcError(
+        GrpcErrorCodes.UNAUTHENTICATED,
+        consensusError.message,
+        { code, ...createRawMetadata(decodedInfo.data) },
+      );
     }
 
     // Fee
     if (code >= 3000 && code < 4000) {
-      return new FailedPreconditionGrpcError(consensusError.message, { code });
+      return new FailedPreconditionGrpcError(
+        consensusError.message,
+        { code, ...createRawMetadata(decodedInfo.data) },
+      );
     }
 
     // State
     if (code >= 4000 && code < 5000) {
-      return new InvalidArgumentGrpcError(consensusError.message, { code });
+      return new InvalidArgumentGrpcError(
+        consensusError.message,
+        { code, ...createRawMetadata(decodedInfo.data) },
+      );
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,8 +136,7 @@
     "@cto.af/textdecoder": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@cto.af/textdecoder/-/textdecoder-0.0.0.tgz",
-      "integrity": "sha512-sJpx3F5xcVV/9jNYJQtvimo4Vfld/nD3ph+ZWtQzZ03Zo8rJC7QKQTRcIGS13Rcz80DwFNthCWMrd58vpY4ZAQ==",
-      "dev": true
+      "integrity": "sha512-sJpx3F5xcVV/9jNYJQtvimo4Vfld/nD3ph+ZWtQzZ03Zo8rJC7QKQTRcIGS13Rcz80DwFNthCWMrd58vpY4ZAQ=="
     },
     "@dashevo/dapi-client": {
       "version": "0.21.0-dev.7",
@@ -213,11 +212,11 @@
       }
     },
     "@dashevo/dp-services-ctl": {
-      "version": "github:dashevo/js-dp-services-ctl#3976076b0018c5b4632ceda4c752fc597f27a640",
+      "version": "github:dashevo/js-dp-services-ctl#3181fee0b1488e76a6598a7a8b733c8e218d6333",
       "from": "github:dashevo/js-dp-services-ctl#v0.19-dev",
       "dev": true,
       "requires": {
-        "@dashevo/dashd-rpc": "^2.3.0",
+        "@dashevo/dashd-rpc": "^2.1.1",
         "dockerode": "^3.2.1",
         "jayson": "^2.1.0",
         "lodash": "^4.17.19",
@@ -267,12 +266,12 @@
       "integrity": "sha512-OnKpFX498ZcJVAEv1MRF/bNpDY0DUHSd+5MjGtSBkZ9plv+E2p6UWHK77479l59ZJWun+Ix2BsYPY7PSd+11yA=="
     },
     "@dashevo/grpc-common": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.4.0.tgz",
-      "integrity": "sha512-w1u7fQOJIEzM0XZf2UdmBaFFrjQRCUOjfZHnasJzENND1uJEOEl5kZIzTwt1ZAxf+Z+Ynif4b8Il8jWnAD6maA==",
+      "version": "github:dashevo/js-grpc-common#ec5e18424ba4a64ae052805bacdfd74de7f1d247",
+      "from": "github:dashevo/js-grpc-common#remove-json-meta",
       "requires": {
         "@grpc/grpc-js": "^1.3.6",
         "@grpc/proto-loader": "^0.5.2",
+        "cbor": "^7.0.6",
         "lodash.get": "^4.4.2",
         "protobufjs": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
         "semver": "^7.3.2"
@@ -282,6 +281,15 @@
           "version": "13.13.52",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
           "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+        },
+        "cbor": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/cbor/-/cbor-7.0.6.tgz",
+          "integrity": "sha512-rgt2RFogHGDLFU5r0kSfyeBc+de55DwYHP73KxKsQxsR5b0CYuQPH6AnJaXByiohpLdjQqj/K0SFcOV+dXdhSA==",
+          "requires": {
+            "@cto.af/textdecoder": "^0.0.0",
+            "nofilter": "^2.0.3"
+          }
         },
         "protobufjs": {
           "version": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
@@ -3269,7 +3277,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-2.0.3.tgz",
       "integrity": "sha512-FbuXC+lK+GU2+63D1kC1ETiZo+Z7SIi7B+mxKTCH1byrh6WFvfBCN/wpherFz0a0bjGd7EKTst/cz0yLeNngug==",
-      "dev": true,
       "requires": {
         "@cto.af/textdecoder": "^0.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,9 +73,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true
     },
     "@babel/highlight": {
@@ -90,9 +90,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.4.tgz",
-      "integrity": "sha512-xmzz+7fRpjrvDUj+GV7zfz/R3gSK2cOxGlazaXooxspCr539cbTXJKvBJzSVI2pPhcRGquoOtaIkKCsHQUiO3w==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
       "dev": true
     },
     "@babel/template": {
@@ -124,9 +124,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
-      "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -139,13 +139,15 @@
       "integrity": "sha512-sJpx3F5xcVV/9jNYJQtvimo4Vfld/nD3ph+ZWtQzZ03Zo8rJC7QKQTRcIGS13Rcz80DwFNthCWMrd58vpY4ZAQ=="
     },
     "@dashevo/dapi-client": {
-      "version": "0.21.0-dev.7",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.21.0-dev.7.tgz",
-      "integrity": "sha512-fNfby71MJasseVRLmNURZvBSFqAhCpkJaSoJhf2AK2zmJ1YDFhJkB0IdnMMyjgfnxrzmVYL8X0wf+fLpiVJ6dw==",
+      "version": "0.21.0-dev.9",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.21.0-dev.9.tgz",
+      "integrity": "sha512-mTAj32BXuvyLQQBERatfzTkSvP/7dbX6tyEnXuVdub613M+J+2XVhFCTbYmRt6ZjsjUx4t2apBW0xYa2pRHCjA==",
       "dev": true,
       "requires": {
-        "@dashevo/dapi-grpc": "~0.21.0-dev.8",
-        "@dashevo/dashcore-lib": "~0.19.25",
+        "@dashevo/dapi-grpc": "~0.21.0-dev.11",
+        "@dashevo/dashcore-lib": "~0.19.26",
+        "@dashevo/dpp": "~0.21.0-dev.4",
+        "@dashevo/grpc-common": "~0.5.3",
         "axios": "^0.21.1",
         "bs58": "^4.0.1",
         "cbor": "^7.0.5",
@@ -166,21 +168,21 @@
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.21.0-dev.8",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.21.0-dev.8.tgz",
-      "integrity": "sha512-/jfmpR7K0mgVWoJvxWd33bfecTKEBcaUE2KI2u6+PyItwYcrK+nxJm36Yt6AzroQBf56Dxvo3lQ6WhU9BwePeQ==",
+      "version": "0.21.0-dev.11",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.21.0-dev.11.tgz",
+      "integrity": "sha512-npRpgtUgqzcwPzVHP0J7ChysWqVUcXjTy9kfs+AckiRZRvZJ/2IWdZZ2oPZ82UTE3G3x0vBI1SaGgKEsdDuHyQ==",
       "requires": {
-        "@dashevo/grpc-common": "^0.4.0",
+        "@dashevo/grpc-common": "^0.5.3",
         "@grpc/grpc-js": "^1.3.6",
         "google-protobuf": "^3.12.2",
         "grpc-web": "^1.2.0",
-        "protobufjs": "github:jawid-h/protobuf.js#fix/buffer-conversion"
+        "protobufjs": "git+https://git@github.com/jawid-h/protobuf.js.git#fix/buffer-conversion"
       }
     },
     "@dashevo/dashcore-lib": {
-      "version": "0.19.25",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.19.25.tgz",
-      "integrity": "sha512-/xVQxotoysCDKUg54Wkc0q/5IICLlUkt+8Pp5zAHI7E8Zf8bQ+CB7P0KzeufkMiUVsIdOZ7INM2sMQYcVk2SeA==",
+      "version": "0.19.26",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.19.26.tgz",
+      "integrity": "sha512-wcGojfHIpEWR4/pjT4CcMmRhI00MbkYT5S29uBhUl7aTNo3Ya75f9YQOXykD03gM3yyCRQSOovmK/cOJU030BQ==",
       "requires": {
         "@dashevo/x11-hash-js": "^1.0.2",
         "@types/node": "^12.12.47",
@@ -196,9 +198,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.23",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.23.tgz",
-          "integrity": "sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw=="
+          "version": "12.20.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.25.tgz",
+          "integrity": "sha512-hcTWqk7DR/HrN9Xe7AlJwuCaL13Vcd9/g/T54YrJz4Q3ESM5mr33YCzW2bOfzSIc3aZMeGBvbLGvgN6mIJ0I5Q=="
         }
       }
     },
@@ -212,11 +214,11 @@
       }
     },
     "@dashevo/dp-services-ctl": {
-      "version": "github:dashevo/js-dp-services-ctl#3181fee0b1488e76a6598a7a8b733c8e218d6333",
+      "version": "github:dashevo/js-dp-services-ctl#3976076b0018c5b4632ceda4c752fc597f27a640",
       "from": "github:dashevo/js-dp-services-ctl#v0.19-dev",
       "dev": true,
       "requires": {
-        "@dashevo/dashd-rpc": "^2.1.1",
+        "@dashevo/dashd-rpc": "^2.3.0",
         "dockerode": "^3.2.1",
         "jayson": "^2.1.0",
         "lodash": "^4.17.19",
@@ -224,9 +226,9 @@
       }
     },
     "@dashevo/dpp": {
-      "version": "0.21.0-dev.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.21.0-dev.4.tgz",
-      "integrity": "sha512-H1QP1ZdZnptYe4rztIdkohts8Y11J2izt6LDkquZR9+kfrpv4gCiWqs+UeslCY06HiaeXVjLUHwk+x7JZOvVNQ==",
+      "version": "0.21.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.21.0-dev.5.tgz",
+      "integrity": "sha512-cONdPkfczI1OIP98sWve++lqBPh2N7Gk0YWvu9s6vsevaHryLroMq4y3MRvS+kRVYhfZfEvW6yVPt2fej3fc9g==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@dashevo/dashcore-lib": "~0.19.25",
@@ -266,22 +268,18 @@
       "integrity": "sha512-OnKpFX498ZcJVAEv1MRF/bNpDY0DUHSd+5MjGtSBkZ9plv+E2p6UWHK77479l59ZJWun+Ix2BsYPY7PSd+11yA=="
     },
     "@dashevo/grpc-common": {
-      "version": "github:dashevo/js-grpc-common#ec5e18424ba4a64ae052805bacdfd74de7f1d247",
-      "from": "github:dashevo/js-grpc-common#remove-json-meta",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.5.3.tgz",
+      "integrity": "sha512-Zst9vK/utmTLlUxM/+oVsMgl3CnaqtuNhgBmQgY9za7sZNPfXSBOzLdP2mezGFMj40orL+fbzFUeA2qhahA+cQ==",
       "requires": {
         "@grpc/grpc-js": "^1.3.6",
         "@grpc/proto-loader": "^0.5.2",
         "cbor": "^7.0.6",
         "lodash.get": "^4.4.2",
-        "protobufjs": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
+        "protobufjs": "git+https://git@github.com/jawid-h/protobuf.js.git#fix/buffer-conversion",
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-        },
         "cbor": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/cbor/-/cbor-7.0.6.tgz",
@@ -289,25 +287,6 @@
           "requires": {
             "@cto.af/textdecoder": "^0.0.0",
             "nofilter": "^2.0.3"
-          }
-        },
-        "protobufjs": {
-          "version": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
-          "from": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": "^13.7.0",
-            "long": "^4.0.0"
           }
         }
       }
@@ -446,9 +425,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "16.7.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
-      "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA=="
+      "version": "16.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
+      "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -478,9 +457,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-      "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -947,9 +926,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "emoji-regex": {
@@ -1152,9 +1131,9 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "default-require-extensions": {
@@ -1214,9 +1193,9 @@
       "dev": true
     },
     "docker-modem": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.0.tgz",
-      "integrity": "sha512-WwFajJ8I5geZ/dDZ5FDMDA6TBkWa76xWwGIGw8uzUjNUGCN0to83wJ8Oi1AxrJTC0JBn+7fvIxUctnawtlwXeg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.2.tgz",
+      "integrity": "sha512-K6ahu0IaJXqRqiAUZYo01n/6MkHir1c5mVJx1//JpyRmePYoIOC7oPR2vSx8rCaxIt7qRc77v9ewxljl6Qatdg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -1245,9 +1224,9 @@
       }
     },
     "dockerode": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.0.tgz",
-      "integrity": "sha512-St08lfOjpYCOXEM8XA0VLu3B3hRjtddODphNW5GFoA0AS3JHgoPQKOz0Qmdzg3P+hUPxhb02g1o1Cu1G+U3lRg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.1.tgz",
+      "integrity": "sha512-AS2mr8Lp122aa5n6d99HkuTNdRV1wkkhHwBdcnY6V0+28D3DSYwhxAk85/mM9XwD3RMliTxyr63iuvn5ZblFYQ==",
       "dev": true,
       "requires": {
         "docker-modem": "^3.0.0",
@@ -1349,22 +1328,23 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-      "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.3",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
+        "is-regex": "^1.1.4",
+        "is-string": "^1.0.7",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -1992,6 +1972,16 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -2035,9 +2025,9 @@
       "dev": true
     },
     "google-protobuf": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.17.3.tgz",
-      "integrity": "sha512-OVPzcSWIAJ+d5yiHyeaLrdufQtrvaBrF4JQg+z8ynTkbO3uFcujqXszTumqg1cGsAsjkWnI+M5B1xZ19yR4Wyg=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.18.0.tgz",
+      "integrity": "sha512-WlaQWRkUOo/lm9uTgNH6nk9IQt814RggWPzKBfnAVewOFzSzRUSmS1yUWRT6ixW1vS7er5p6tmLSmwzpPpmc8A=="
     },
     "graceful-fs": {
       "version": "4.2.8",
@@ -3157,9 +3147,9 @@
       "dev": true
     },
     "mongodb": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.0.tgz",
-      "integrity": "sha512-JOAYjT9WYeRFkIP6XtDidAr3qvpfLRJhT2iokRWWH0tgqCQr9kmSfOJBZ3Ry0E5A3EqKxVPVhN3MV8Gn03o7pA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.1.tgz",
+      "integrity": "sha512-iSVgexYr8ID0ieeNFUbRfQeOZxOchRck6kEDVySQRaa8VIw/1Pm+/LgcpZcl/BWV6nT0L8lP9qyl7dRPJ6mnLw==",
       "dev": true,
       "requires": {
         "bl": "^2.2.1",
@@ -3824,8 +3814,8 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
-      "from": "github:jawid-h/protobuf.js#fix/buffer-conversion",
+      "version": "git+https://git@github.com/jawid-h/protobuf.js.git#8b91c72dca68fd6c418078fd2358c4969425dcdc",
+      "from": "git+https://git@github.com/jawid-h/protobuf.js.git#fix/buffer-conversion",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -4157,9 +4147,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
+      "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q=="
     },
     "simple-concat": {
       "version": "1.0.1",
@@ -4870,9 +4860,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -4959,9 +4949,9 @@
       }
     },
     "ws": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg=="
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
     },
     "y18n": {
       "version": "5.0.8",
@@ -4990,9 +4980,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@dashevo/dashcore-lib": "~0.19.25",
     "@dashevo/dashd-rpc": "^2.0.2",
     "@dashevo/dpp": "~0.21.0-dev.4",
-    "@dashevo/grpc-common": "~0.4.0",
+    "@dashevo/grpc-common": "github:dashevo/js-grpc-common#remove-json-meta",
     "@grpc/grpc-js": "^1.3.6",
     "ajv": "^8.6.0",
     "bs58": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@dashevo/dashcore-lib": "~0.19.25",
     "@dashevo/dashd-rpc": "^2.0.2",
     "@dashevo/dpp": "~0.21.0-dev.4",
-    "@dashevo/grpc-common": "github:dashevo/js-grpc-common#remove-json-meta",
+    "@dashevo/grpc-common": "~0.5.3",
     "@grpc/grpc-js": "^1.3.6",
     "ajv": "^8.6.0",
     "bs58": "^4.0.1",

--- a/test/integration/dpp/DriveStateRepository.spec.js
+++ b/test/integration/dpp/DriveStateRepository.spec.js
@@ -55,10 +55,12 @@ describe('DriveStateRepository', () => {
 
       expect(result.toObject()).to.be.deep.equal(dataContractFixture.toObject());
 
-      expect(dpp.dataContract.createFromBuffer).to.be.calledOnce();
-      expect(dpp.dataContract.createFromBuffer.getCall(0).args).to.have.deep.members([
+      expect(dpp.dataContract.createFromBuffer).to.be.calledOnceWithExactly(
         proto.getDataContract_asU8(),
-      ]);
+        {
+          skipValidation: true,
+        },
+      );
 
       expect(driveClientMock.fetchDataContract).to.be.calledOnce();
       expect(driveClientMock.fetchDataContract).to.be.calledWithExactly(contractId, false);

--- a/test/unit/externalApis/drive/DriveClient.js
+++ b/test/unit/externalApis/drive/DriveClient.js
@@ -55,7 +55,7 @@ describe('DriveClient', () => {
           response: {
             code: GrpcErrorCodes.INVALID_ARGUMENT,
             info: cbor.encode({
-              metadata: {
+              data: {
                 name: 'someData',
               },
               message: 'some message',
@@ -71,7 +71,9 @@ describe('DriveClient', () => {
       expect(e.getCode()).to.equal(3);
       expect(e.getMessage()).to.equal('some message');
       expect(e.getRawMetadata()).to.deep.equal({
-        name: 'someData',
+        'drive-error-data-bin': cbor.encode({
+          name: 'someData',
+        }),
       });
     }
   });

--- a/test/unit/grpcServer/handlers/platform/getConsensusParamsHandlerFactory.js
+++ b/test/unit/grpcServer/handlers/platform/getConsensusParamsHandlerFactory.js
@@ -89,7 +89,7 @@ describe('getConsensusParamsHandlerFactory', () => {
       expect.fail('should throw FailedPreconditionGrpcError');
     } catch (e) {
       expect(e).to.be.an.instanceOf(FailedPreconditionGrpcError);
-      expect(e.getMessage()).to.equal('Failed precondition: Invalid height: some data');
+      expect(e.getMessage()).to.equal('Invalid height: some data');
       expect(e.getCode()).to.equal(9);
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive's error data is sent as JSON in gRPC metadata so it can't be restored by client. Also, arguments for DPP consensus errors weren't sent at all.

## What was done?
<!--- Describe your changes in detail -->
- Drive's error data cbored to `drive-error-data-bin` gRPC metadata field

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
